### PR TITLE
Added support for Hibernate 5 and 5.1.

### DIFF
--- a/hazelcast-hibernate5/pom.xml
+++ b/hazelcast-hibernate5/pom.xml
@@ -1,0 +1,84 @@
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>hazelcast-hibernate5</name>
+    <artifactId>hazelcast-hibernate5</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-hibernate</artifactId>
+        <version>3.7-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
+
+        <hibernate.core.version>5.0.7.Final</hibernate.core.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Fragment-Host>com.hazelcast</Fragment-Host>
+                                <Import-Package>!com.hazelcast.*, *</Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate.core.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <version>1.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.instance.HazelcastInstanceFactory;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
+import com.hazelcast.hibernate.local.CleanupService;
+import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.QueryResultsRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+
+import java.util.Properties;
+
+/**
+ * Abstract superclass of Hazelcast based {@link RegionFactory} implementations
+ *
+ * @since 3.7
+ */
+public abstract class AbstractHazelcastCacheRegionFactory implements RegionFactory {
+
+    protected HazelcastInstance instance;
+    protected CleanupService cleanupService;
+    private final ILogger log = Logger.getLogger(getClass());
+
+    private IHazelcastInstanceLoader instanceLoader;
+
+
+    public AbstractHazelcastCacheRegionFactory() {
+    }
+
+    public AbstractHazelcastCacheRegionFactory(final Properties properties) {
+        this();
+    }
+
+    public AbstractHazelcastCacheRegionFactory(final HazelcastInstance instance) {
+        this.instance = instance;
+    }
+
+    @Override
+    public final QueryResultsRegion buildQueryResultsRegion(final String regionName, final Properties properties)
+            throws CacheException {
+        HazelcastQueryResultsRegion region = new HazelcastQueryResultsRegion(instance, regionName, properties);
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    /**
+     * @return true - for a large cluster, unnecessary puts will most likely slow things down.
+     */
+    @Override
+    public boolean isMinimalPutsEnabledByDefault() {
+        return true;
+    }
+
+    @Override
+    public long nextTimestamp() {
+        return HazelcastTimestamper.nextTimestamp(instance);
+    }
+
+    @Override
+    public void start(final SessionFactoryOptions options, final Properties properties) throws CacheException {
+        log.info("Starting up " + getClass().getSimpleName());
+        if (instance == null || !instance.getLifecycleService().isRunning()) {
+            instanceLoader = HazelcastInstanceFactory.createInstanceLoader(properties);
+            instance = instanceLoader.loadInstance();
+        }
+        cleanupService = new CleanupService(instance.getName());
+    }
+
+    @Override
+    public void stop() {
+        if (instanceLoader != null) {
+            log.info("Shutting down " + getClass().getSimpleName());
+            instanceLoader.unloadInstance();
+            instance = null;
+            instanceLoader = null;
+        }
+        cleanupService.stop();
+    }
+
+    public HazelcastInstance getHazelcastInstance() {
+        return instance;
+    }
+
+    @Override
+    public AccessType getDefaultAccessType() {
+        return AccessType.READ_WRITE;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.logging.Logger;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import java.util.Properties;
+
+/**
+ * This class is used to help in setup the internal caches. It searches for configuration files
+ * and contains all property names for hibernate based configuration properties.
+ */
+public final class CacheEnvironment {
+
+    /**
+     * Legacy property to configure the path of the hazelcast.xml or hazelcast-client.xml configuration files
+     */
+    @Deprecated
+    public static final String CONFIG_FILE_PATH_LEGACY = Environment.CACHE_PROVIDER_CONFIG;
+
+    /**
+     * Property to configure the path of the hazelcast.xml or hazelcast-client.xml configuration files
+     */
+    public static final String CONFIG_FILE_PATH = "hibernate.cache.hazelcast.configuration_file_path";
+
+    /**
+     * Property to configure weather a Hazelcast client or node will be used for connection to the cluster
+     */
+    public static final String USE_NATIVE_CLIENT = "hibernate.cache.hazelcast.use_native_client";
+
+    /**
+     * Property to configure the address for the Hazelcast client to connect to
+     */
+    public static final String NATIVE_CLIENT_ADDRESS = "hibernate.cache.hazelcast.native_client_address";
+
+    /**
+     * Property to configure Hazelcast client group name
+     */
+    public static final String NATIVE_CLIENT_GROUP = "hibernate.cache.hazelcast.native_client_group";
+
+    /**
+     * Property to configure Hazelcast client group password
+     */
+    public static final String NATIVE_CLIENT_PASSWORD = "hibernate.cache.hazelcast.native_client_password";
+
+    /**
+     * Property to configure if the HazelcastInstance should going to shutdown when the RegionFactory is being stopped
+     */
+    public static final String SHUTDOWN_ON_STOP = "hibernate.cache.hazelcast.shutdown_on_session_factory_close";
+
+    /**
+     * Property to configure the timeout delay before a lock eventually times out
+     */
+    public static final String LOCK_TIMEOUT = "hibernate.cache.hazelcast.lock_timeout";
+
+    /**
+     * Property to configure the Hazelcast instance internal name
+     */
+    public static final String HAZELCAST_INSTANCE_NAME = "hibernate.cache.hazelcast.instance_name";
+
+    /**
+     * Property to configure explicitly checks the CacheEntry's version while updating RegionCache.
+     * If new entry's version is not higher then previous, update will be cancelled.
+     */
+    public static final String EXPLICIT_VERSION_CHECK = "hibernate.cache.hazelcast.explicit_version_check";
+
+    // milliseconds
+    private static final int MAXIMUM_LOCK_TIMEOUT = 10000;
+
+    // one hour in milliseconds
+    private static final int DEFAULT_CACHE_TIMEOUT = (3600 * 1000);
+
+    private CacheEnvironment() {
+    }
+
+    public static String getConfigFilePath(final Properties props) {
+        String configResourcePath = ConfigurationHelper.getString(CacheEnvironment.CONFIG_FILE_PATH_LEGACY, props, null);
+        if (StringHelper.isEmpty(configResourcePath)) {
+            configResourcePath = ConfigurationHelper.getString(CacheEnvironment.CONFIG_FILE_PATH, props, null);
+        }
+        return configResourcePath;
+    }
+
+    public static String getInstanceName(final Properties props) {
+        return ConfigurationHelper.getString(HAZELCAST_INSTANCE_NAME, props, null);
+    }
+
+    public static boolean isNativeClient(final Properties props) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.USE_NATIVE_CLIENT, props, false);
+    }
+
+    public static int getDefaultCacheTimeoutInMillis() {
+        return DEFAULT_CACHE_TIMEOUT;
+    }
+
+    public static int getLockTimeoutInMillis(final Properties props) {
+        int timeout = -1;
+        try {
+            timeout = ConfigurationHelper.getInt(LOCK_TIMEOUT, props, -1);
+        } catch (Exception e) {
+            Logger.getLogger(CacheEnvironment.class).finest(e);
+        }
+        if (timeout < 0) {
+            timeout = MAXIMUM_LOCK_TIMEOUT;
+        }
+        return timeout;
+    }
+
+    public static boolean shutdownOnStop(final Properties props, final boolean defaultValue) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.SHUTDOWN_ON_STOP, props, defaultValue);
+    }
+
+    public static boolean isExplicitVersionCheckEnabled(final Properties props) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.EXPLICIT_VERSION_CHECK, props, false);
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.distributed.IMapRegionCache;
+import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
+import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
+import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.*;
+
+import java.util.Properties;
+
+/**
+ * Simple RegionFactory implementation to return Hazelcast based Region implementations
+ *
+ * @since 3.7
+ */
+public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFactory implements RegionFactory {
+
+    public HazelcastCacheRegionFactory() {
+    }
+
+    public HazelcastCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    public HazelcastCacheRegionFactory(final Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public CollectionRegion buildCollectionRegion(final String regionName, final Properties properties,
+                                                  final CacheDataDescription metadata) throws CacheException {
+        return new HazelcastCollectionRegion<IMapRegionCache>(instance, regionName, properties, metadata,
+                new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    @Override
+    public EntityRegion buildEntityRegion(final String regionName, final Properties properties,
+                                          final CacheDataDescription metadata) throws CacheException {
+        return new HazelcastEntityRegion<IMapRegionCache>(instance, regionName, properties, metadata,
+                new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    @Override
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
+                                                final CacheDataDescription metadata) throws CacheException {
+        return new HazelcastNaturalIdRegion<IMapRegionCache>(instance, regionName, properties, metadata,
+                new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    @Override
+    public TimestampsRegion buildTimestampsRegion(final String regionName, final Properties properties)
+            throws CacheException {
+        return new HazelcastTimestampsRegion<IMapRegionCache>(instance, regionName, properties,
+                new IMapRegionCache(regionName, instance, properties, null));
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.hibernate.local.TimestampsRegionCache;
+import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
+import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
+import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.*;
+
+import java.util.Properties;
+
+/**
+ * Simple RegionFactory implementation to return Hazelcast based local Region implementations
+ *
+ * @since 3.7
+ */
+public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegionFactory implements RegionFactory {
+
+    private static final int serialVersionUID = 1;
+
+    public HazelcastLocalCacheRegionFactory() {
+    }
+
+    public HazelcastLocalCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    public HazelcastLocalCacheRegionFactory(final Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public CollectionRegion buildCollectionRegion(final String regionName, final Properties properties,
+                                                  final CacheDataDescription metadata) throws CacheException {
+        final HazelcastCollectionRegion<LocalRegionCache> region = new HazelcastCollectionRegion<LocalRegionCache>(instance,
+                regionName, properties, metadata, new LocalRegionCache(regionName, instance, null));
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    @Override
+    public EntityRegion buildEntityRegion(final String regionName, final Properties properties,
+                                          final CacheDataDescription metadata) throws CacheException {
+        final HazelcastEntityRegion<LocalRegionCache> region = new HazelcastEntityRegion<LocalRegionCache>(instance,
+                regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    @Override
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
+                                                final CacheDataDescription metadata) throws CacheException {
+        final HazelcastNaturalIdRegion<LocalRegionCache> region = new HazelcastNaturalIdRegion<LocalRegionCache>(
+                instance, regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        cleanupService.registerCache(region.getCache());
+
+        return region;
+    }
+
+    @Override
+    public TimestampsRegion buildTimestampsRegion(final String regionName, final Properties properties)
+            throws CacheException {
+        return new HazelcastTimestampsRegion<LocalRegionCache>(instance, regionName, properties,
+                new TimestampsRegionCache(regionName, instance));
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.logging.Logger;
+
+/**
+ * Helper class to create timestamps and calculate timeouts based on either Hazelcast
+ * configuration of by requesting values on the cluster.
+ *
+ * @since 3.7
+ */
+public final class HazelcastTimestamper {
+
+    private static final int SEC_TO_MS = 1000;
+
+    private HazelcastTimestamper() {
+    }
+
+    public static long nextTimestamp(final HazelcastInstance instance) {
+        // System time in ms.
+        return instance.getCluster().getClusterTime();
+    }
+
+    public static int getTimeout(final HazelcastInstance instance, final String regionName) {
+        try {
+            final MapConfig cfg = instance.getConfig().findMapConfig(regionName);
+            if (cfg.getTimeToLiveSeconds() > 0) {
+                // TTL in ms
+                return cfg.getTimeToLiveSeconds() * SEC_TO_MS;
+            }
+        } catch (UnsupportedOperationException e) {
+            // HazelcastInstance is instance of HazelcastClient.
+            Logger.getLogger(HazelcastTimestamper.class).finest(e);
+        }
+        return CacheEnvironment.getDefaultCacheTimeoutInMillis();
+    }
+
+    public static long getMaxOperationTimeout(final HazelcastInstance instance) {
+        String maxOpTimeoutProp = null;
+        try {
+            Config config = instance.getConfig();
+            maxOpTimeoutProp = config.getProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS);
+        } catch (UnsupportedOperationException e) {
+            // HazelcastInstance is instance of HazelcastClient.
+            Logger.getLogger(HazelcastTimestamper.class).finest(e);
+        }
+        if (maxOpTimeoutProp != null) {
+            return Long.parseLong(maxOpTimeoutProp);
+        }
+        return Long.MAX_VALUE;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/RegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/RegionCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Map;
+
+/**
+ * This interface defines an internal cached region implementation as well as a mechanism
+ * to unmap the cache to an underlying Map data-structure
+ *
+ * @since 3.7
+ */
+public interface RegionCache {
+
+    Object get(final Object key, final long txTimestamp);
+
+    boolean insert(final Object key, final Object value, final Object currentVersion);
+
+    boolean put(final Object key, final Object value, final long txTimestamp, final Object version);
+
+    boolean update(final Object key, final Object newValue, final Object newVersion, final SoftLock lock);
+
+    boolean remove(final Object key);
+
+    SoftLock tryLock(final Object key, final Object version);
+
+    void unlock(final Object key, final SoftLock lock);
+
+    boolean contains(final Object key);
+
+    void clear();
+
+    long size();
+
+    long getSizeInMemory();
+
+    Map asMap();
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.merge.MapMergePolicy;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import org.hibernate.cache.spi.entry.CacheEntry;
+
+import java.io.IOException;
+
+/**
+ * A merge policy implementation to handle split brain remerges based on the timestamps stored in
+ * the values.
+ *
+ * @since 3.7
+ */
+public class VersionAwareMapMergePolicy implements MapMergePolicy {
+
+    @Override
+    public Object merge(final String mapName, final EntryView mergingEntry, final EntryView existingEntry) {
+        final Object existingValue = existingEntry != null ? existingEntry.getValue() : null;
+        final Object mergingValue = mergingEntry.getValue();
+        if (existingValue != null && existingValue instanceof CacheEntry
+                && mergingValue != null && mergingValue instanceof CacheEntry) {
+
+            final CacheEntry existingCacheEntry = (CacheEntry) existingValue;
+            final CacheEntry mergingCacheEntry = (CacheEntry) mergingValue;
+            final Object mergingVersionObject = mergingCacheEntry.getVersion();
+            final Object existingVersionObject = existingCacheEntry.getVersion();
+            if (mergingVersionObject != null && existingVersionObject != null
+                    && mergingVersionObject instanceof Comparable && existingVersionObject instanceof Comparable) {
+
+                final Comparable mergingVersion = (Comparable) mergingVersionObject;
+                final Comparable existingVersion = (Comparable) existingVersionObject;
+
+                if (mergingVersion.compareTo(existingVersion) > 0) {
+                    return mergingValue;
+                } else {
+                    return existingValue;
+                }
+            }
+        }
+        return mergingValue;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/AbstractAccessDelegate.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/AbstractAccessDelegate.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.region.AbstractTransactionalDataRegion;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.logging.ILogger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Comparator;
+import java.util.Properties;
+
+/**
+ * Base implementation for consistency guarantees
+ *
+ * @param <T> implementation type of HazelcastRegion
+ * @since 3.7
+ */
+public abstract class AbstractAccessDelegate<T extends HazelcastRegion> implements AccessDelegate<T> {
+
+    protected final ILogger log;
+    protected final T hazelcastRegion;
+    protected final RegionCache cache;
+    protected final Comparator<Object> versionComparator;
+
+    protected AbstractAccessDelegate(final T hazelcastRegion, final Properties props) {
+        this.hazelcastRegion = hazelcastRegion;
+        log = hazelcastRegion.getLogger();
+        if (hazelcastRegion instanceof AbstractTransactionalDataRegion) {
+            this.versionComparator = ((AbstractTransactionalDataRegion) hazelcastRegion)
+                    .getCacheDataDescription().getVersionComparator();
+        } else {
+            this.versionComparator = null;
+        }
+        cache = hazelcastRegion.getCache();
+    }
+
+    @Override
+    public final T getHazelcastRegion() {
+        return hazelcastRegion;
+    }
+
+    @Override
+    public Object get(final Object key, final long txTimestamp) throws CacheException {
+        try {
+            return cache.get(key, txTimestamp);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not read from Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public boolean putFromLoad(final Object key, final Object value, final long txTimestamp,
+                               final Object version) throws CacheException {
+        try {
+            return cache.put(key, value, txTimestamp, version);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not put into Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean putFromLoad(final Object key, final Object value, final long txTimestamp,
+                               final Object version, boolean minimalPuts) throws CacheException {
+        return putFromLoad(key, value, txTimestamp, version);
+    }
+
+    @Override
+    public void evict(final Object key) throws CacheException {
+        cache.remove(key);
+    }
+
+    @Override
+    public void evictAll() throws CacheException {
+        cache.clear();
+    }
+
+    /**
+     * NO-OP
+     */
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        return null;
+    }
+
+    @Override
+    public void unlockRegion(final SoftLock lock) throws CacheException {
+        cache.clear();
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/AccessDelegate.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/AccessDelegate.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+/**
+ * This interface is used to implement basic transactional guarantees
+ *
+ * @param <T> implementation type of HazelcastRegion
+ * @since 3.7
+ */
+public interface AccessDelegate<T extends HazelcastRegion> {
+
+    /**
+     * Get the wrapped cache region
+     *
+     * @return The underlying region
+     */
+    T getHazelcastRegion();
+
+    /**
+     * Attempt to retrieve an object from the cache. Mainly used in attempting
+     * to resolve entities/collections from the second level cache.
+     *
+     * @param key         The key of the item to be retrieved.
+     * @param txTimestamp a timestamp prior to the transaction start time
+     * @return the cached object or <tt>null</tt>
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    Object get(final Object key, final long txTimestamp) throws CacheException;
+
+    /**
+     * Called after an item has been inserted (before the transaction completes),
+     * instead of calling evict().
+     * This method is used by "synchronous" concurrency strategies.
+     *
+     * @param key     The item key
+     * @param value   The item
+     * @param version The item's version value
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean insert(final Object key, final Object value, final Object version) throws CacheException;
+
+    /**
+     * Called after an item has been inserted (after the transaction completes),
+     * instead of calling release().
+     * This method is used by "asynchronous" concurrency strategies.
+     *
+     * @param key     The item key
+     * @param value   The item
+     * @param version The item's version value
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException;
+
+    /**
+     * Called after an item has been updated (before the transaction completes),
+     * instead of calling evict(). This method is used by "synchronous" concurrency
+     * strategies.
+     *
+     * @param key             The item key
+     * @param value           The item
+     * @param currentVersion  The item's current version value
+     * @param previousVersion The item's previous version value
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean update(final Object key, final Object value, final Object currentVersion, final Object previousVersion)
+            throws CacheException;
+
+    /**
+     * Called after an item has been updated (after the transaction completes),
+     * instead of calling release().  This method is used by "asynchronous"
+     * concurrency strategies.
+     *
+     * @param key             The item key
+     * @param value           The item
+     * @param currentVersion  The item's current version value
+     * @param previousVersion The item's previous version value
+     * @param lock            The lock previously obtained from {@link #lockItem}
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                        final Object previousVersion, final SoftLock lock)
+            throws CacheException;
+
+    /**
+     * Attempt to cache an object, after loading from the database.
+     *
+     * @param key         The item key
+     * @param value       The item
+     * @param txTimestamp a timestamp prior to the transaction start time
+     * @param version     the item version number
+     * @return <tt>true</tt> if the object was successfully cached
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean putFromLoad(final Object key, final Object value, final long txTimestamp, final Object version)
+            throws CacheException;
+
+    /**
+     * Attempt to cache an object, after loading from the database, explicitly
+     * specifying the minimalPut behavior.
+     *
+     * @param key                The item key
+     * @param value              The item
+     * @param txTimestamp        a timestamp prior to the transaction start time
+     * @param version            the item version number
+     * @param minimalPutOverride Explicit minimalPut flag
+     * @return <tt>true</tt> if the object was successfully cached
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean putFromLoad(final Object key, final Object value, final long txTimestamp, final Object version,
+                        final boolean minimalPutOverride) throws CacheException;
+
+    /**
+     * Called after an item has become stale (before the transaction completes).
+     * This method is used by "synchronous" concurrency strategies.
+     *
+     * @param key The key of the item to remove
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void remove(final Object key) throws CacheException;
+
+    /**
+     * Called to evict data from the entire region
+     *
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void removeAll() throws CacheException;
+
+    /**
+     * Forcibly evict an item from the cache immediately without regard for transaction
+     * isolation.
+     *
+     * @param key The key of the item to remove
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void evict(final Object key) throws CacheException;
+
+    /**
+     * Forcibly evict all items from the cache immediately without regard for transaction
+     * isolation.
+     *
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void evictAll() throws CacheException;
+
+    /**
+     * We are going to attempt to update/delete the keyed object. This
+     * method is used by "asynchronous" concurrency strategies.
+     * <p/>
+     * The returned object must be passed back to release(), to release the
+     * lock. Concurrency strategies which do not support client-visible
+     * locks may silently return null.
+     *
+     * @param key     The key of the item to lock
+     * @param version The item's current version value
+     * @return A representation of our lock on the item; or null.
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    SoftLock lockItem(final Object key, final Object version) throws CacheException;
+
+    /**
+     * Lock the entire region
+     *
+     * @return A representation of our lock on the item; or null.
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    SoftLock lockRegion() throws CacheException;
+
+    /**
+     * Called when we have finished the attempted update/delete (which may or
+     * may not have been successful), after transaction completion.  This method
+     * is used by "asynchronous" concurrency strategies.
+     *
+     * @param key  The item key
+     * @param lock The lock previously obtained from {@link #lockItem}
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void unlockItem(final Object key, final SoftLock lock) throws CacheException;
+
+    /**
+     * Called after we have finished the attempted invalidation of the entire
+     * region
+     *
+     * @param lock The lock previously obtained from {@link #lockRegion}
+     * @throws org.hibernate.cache.CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void unlockRegion(final SoftLock lock) throws CacheException;
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/NonStrictReadWriteAccessDelegate.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/NonStrictReadWriteAccessDelegate.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Properties;
+
+/**
+ * Makes no guarantee of consistency between the cache and the database. Stale data from the cache is possible if expiry
+ * is not configured appropriately.
+ *
+ * @param <T> implementation type of HazelcastRegion
+ * @since 3.7
+ */
+public class NonStrictReadWriteAccessDelegate<T extends HazelcastRegion> extends AbstractAccessDelegate<T> {
+
+    public NonStrictReadWriteAccessDelegate(T hazelcastRegion, final Properties props) {
+        super(hazelcastRegion, props);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Returns <code>false</code> since this is a non-strict read/write cache access strategy
+     */
+    @Override
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    @Override
+    public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                               final Object previousVersion, final SoftLock lock) throws CacheException {
+        unlockItem(key, lock);
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Returns <code>false</code> since this is an asynchronous cache access strategy.
+     */
+    @Override
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Removes the entry since this is a non-strict read/write cache strategy.
+     */
+    @Override
+    public boolean update(final Object key, final Object value, final Object currentVersion,
+                          final Object previousVersion) {
+        remove(key);
+        return false;
+    }
+
+    @Override
+    public void remove(final Object key) throws CacheException {
+        try {
+            cache.remove(key);
+        } catch (HazelcastException e) {
+            throw new CacheException("Operation timeout during remove operation from cache!", e);
+        }
+    }
+
+    @Override
+    public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public void removeAll() throws CacheException {
+        cache.clear();
+    }
+
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        remove(key);
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Properties;
+
+/**
+ * Guarantees that view is read-only and no updates can be made
+ *
+ * @param <T> implementation type of HazelcastRegion
+ * @since 3.7
+ */
+public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrictReadWriteAccessDelegate<T> {
+
+    public ReadOnlyAccessDelegate(T hazelcastRegion, final Properties props) {
+        super(hazelcastRegion, props);
+    }
+
+    @Override
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        return cache.insert(key, value, version);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                               final Object previousVersion, final SoftLock lock) throws CacheException {
+        throw new UnsupportedOperationException("Cannot update an item in a read-only cache: "
+                + getHazelcastRegion().getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * This cache is asynchronous hence a no-op
+     */
+    @Override
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    @Override
+    public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        return null;
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        throw new UnsupportedOperationException("Attempting to lock a read-only cache region: "
+                + getHazelcastRegion().getName());
+    }
+
+    @Override
+    public void removeAll() throws CacheException {
+        cache.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Should be a no-op since this cache is read-only
+     */
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        /*
+         * To err on the safe side though, follow ReadOnlyEhcacheEntityRegionAccessStrategy which nevertheless evicts
+         * the key.
+         */
+        evict(key);
+    }
+
+    /**
+     * This will issue a log warning stating that an attempt was made to unlock a read-only cache region.
+     */
+    @Override
+    public void unlockRegion(final SoftLock lock) throws CacheException {
+        log.warning("Attempting to unlock a read-only cache region");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public boolean update(final Object key, final Object value, final Object currentVersion,
+                          final Object previousVersion) throws CacheException {
+        throw new UnsupportedOperationException("Attempting to update an item in a read-only cache: "
+                + getHazelcastRegion().getName());
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegate.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegate.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Properties;
+
+/**
+ * Makes <b>READ COMMITTED</b> consistency guarantees even in a clustered environment.
+ *
+ * @param <T> implementation type of HazelcastRegion
+ * @since 3.7
+ */
+public class ReadWriteAccessDelegate<T extends HazelcastRegion> extends AbstractAccessDelegate<T> {
+
+
+    public ReadWriteAccessDelegate(T hazelcastRegion, final Properties props) {
+        super(hazelcastRegion, props);
+    }
+
+    @Override
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        try {
+            return cache.insert(key, value, version);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not insert into Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Called after <code>com.hazelcast.ReadWriteAccessDelegate.lockItem()</code>
+     */
+    @Override
+    public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                               final Object previousVersion, final SoftLock lock) throws CacheException {
+        try {
+            return cache.update(key, value, currentVersion, lock);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not update Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
+        }
+    }
+
+    /**
+     * This is an asynchronous cache access strategy.
+     * NO-OP
+     */
+    @Override
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    @Override
+    public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        return cache.tryLock(key, version);
+    }
+
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        cache.unlock(key, lock);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * A no-op since this is an asynchronous cache access strategy.
+     */
+    @Override
+    public boolean update(final Object key, final Object value, final Object currentVersion,
+                          final Object previousVersion) throws CacheException {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * A no-op since this is an asynchronous cache access strategy.
+     */
+    @Override
+    public void remove(final Object key) throws CacheException {
+    }
+
+    /**
+     * This is an asynchronous cache access strategy.
+     * NO-OP
+     */
+    @Override
+    public void removeAll() throws CacheException {
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/package-info.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides access interfaces/classes for Hibernate.
+ * such as AccessDelegate, ReadWriteAccessDelegate.
+ */
+package com.hazelcast.hibernate.access;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/AbstractRegionCacheEntryProcessor.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/AbstractRegionCacheEntryProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.util.Map;
+
+/**
+ * An abstract implementation of {@link EntryProcessor} which acts on a hibernate region cache
+ * {@link com.hazelcast.core.IMap}
+ *
+ * @since 3.7
+ */
+public abstract class AbstractRegionCacheEntryProcessor implements EntryProcessor<Object, Expirable>,
+        EntryBackupProcessor<Object, Expirable>, IdentifiedDataSerializable {
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public void processBackup(final Map.Entry<Object, Expirable> entry) {
+        process(entry);
+    }
+
+    @Override
+    public EntryBackupProcessor<Object, Expirable> getBackupProcessor() {
+        return this;
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.hibernate.HazelcastTimestamper;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.MarkerWrapper;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.hibernate.HazelcastTimestamper.nextTimestamp;
+
+/**
+ * A {@link RegionCache} implementation based on the underlying IMap
+ * <p/>
+ * Note, IMap locks are intentionally not used in this class. Hibernate region caches make use of a concept
+ * called soft-locking which has the following properties:
+ * <ul>
+ *     <li>Multiple transactions can soft-lock an entry concurrently</li>
+ *     <li>While an entry is soft-locked, the value of the cache entry is always {@code null}</li>
+ *     <li>An entry is unlocked from a soft-lock when all transactions complete</li>
+ *     <li>An entry is unlocked if it reaches the configured lock timeout</li>
+ * </ul>
+ * These requirements are incompatible with IMap locks
+ *
+ * @since 3.7
+ */
+public class IMapRegionCache implements RegionCache {
+
+    private static final long COMPARISON_VALUE = 500;
+
+    private final String name;
+    private final HazelcastInstance hazelcastInstance;
+    private final IMap<Object, Expirable> map;
+    private final Comparator versionComparator;
+    private final int lockTimeout;
+    private final long tryLockAndGetTimeout;
+    private final AtomicLong markerIdCounter;
+
+    public IMapRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                           final Properties props, final CacheDataDescription metadata) {
+        this.name = name;
+        this.hazelcastInstance = hazelcastInstance;
+        this.versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
+        this.map = hazelcastInstance.getMap(this.name);
+        lockTimeout = CacheEnvironment.getLockTimeoutInMillis(props);
+        final long maxOperationTimeout = HazelcastTimestamper.getMaxOperationTimeout(hazelcastInstance);
+        tryLockAndGetTimeout = Math.min(maxOperationTimeout, COMPARISON_VALUE);
+        markerIdCounter = new AtomicLong();
+    }
+
+    @Override
+    public Object get(final Object key, final long txTimestamp) {
+        Expirable entry = map.get(key);
+        return entry == null ? null : entry.getValue(txTimestamp);
+    }
+
+    @Override
+    public boolean insert(final Object key, final Object value, final Object currentVersion) {
+        return map.putIfAbsent(key, new Value(currentVersion, nextTimestamp(hazelcastInstance), value)) == null;
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        // Ideally this would be an entry processor. Unfortunately there is no guarantee that
+        // the versionComparator is Serializable.
+        //
+        // Alternatively this could be implemented using a `map.get` followed by `map.set` wrapped inside a
+        // `map.tryLock` block. Unfortunately this implementation was prone to `IllegalMonitorStateException` when
+        // the lock was released under heavy load or after network partitions. Hence this implementation now uses
+        // a spin loop around atomic operations.
+        long timeout = System.currentTimeMillis() + tryLockAndGetTimeout;
+        do {
+            Expirable previousEntry = map.get(key);
+            Value newValue = new Value(version, txTimestamp, value);
+            if (previousEntry == null) {
+                if (map.putIfAbsent(key, newValue) == null) {
+                    return true;
+                }
+            } else if (previousEntry.isReplaceableBy(txTimestamp, version, versionComparator)) {
+                if (map.replace(key, previousEntry, newValue)) {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        } while (System.currentTimeMillis() < timeout);
+
+        return false;
+    }
+
+    @Override
+    public boolean update(final Object key, final Object newValue, final Object newVersion, final SoftLock lock) {
+        if (lock instanceof MarkerWrapper) {
+            final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+            return (Boolean) map.executeOnKey(key, new UpdateEntryProcessor(unwrappedMarker, newValue, newVersion,
+                    nextMarkerId(), nextTimestamp(hazelcastInstance)));
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean remove(final Object key) {
+        return map.remove(key) != null;
+    }
+
+    @Override
+    public SoftLock tryLock(final Object key, final Object version) {
+        long timeout = nextTimestamp(hazelcastInstance) + lockTimeout;
+        final ExpiryMarker marker = (ExpiryMarker) map.executeOnKey(key,
+                new LockEntryProcessor(nextMarkerId(), timeout, version));
+        return new MarkerWrapper(marker);
+    }
+
+    @Override
+    public void unlock(final Object key, final SoftLock lock) {
+        if (lock instanceof MarkerWrapper) {
+            final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+            map.executeOnKey(key, new UnlockEntryProcessor(unwrappedMarker, nextMarkerId(),
+                    nextTimestamp(hazelcastInstance)));
+        }
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public void clear() {
+        map.evictAll();
+    }
+
+    @Override
+    public long size() {
+        return map.size();
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        long size = 0;
+        for (final Object key : map.keySet()) {
+            final EntryView entry = map.getEntryView(key);
+            if (entry != null) {
+                size += entry.getCost();
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public Map asMap() {
+        return map;
+    }
+
+    private String nextMarkerId() {
+        return hazelcastInstance.getLocalEndpoint().getUuid() + markerIdCounter.getAndIncrement();
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/LockEntryProcessor.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/LockEntryProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A concrete implementation of {@link com.hazelcast.map.EntryProcessor} which soft-locks
+ * a region cached entry
+ *
+ * @since 3.7
+ */
+public class LockEntryProcessor extends AbstractRegionCacheEntryProcessor {
+
+    private String nextMarkerId;
+    private long timeout;
+    private Object version;
+
+    public LockEntryProcessor() {
+    }
+
+    public LockEntryProcessor(final String nextMarkerId, final long timeout, final Object version) {
+        this.nextMarkerId = nextMarkerId;
+        this.timeout = timeout;
+        this.version = version;
+    }
+
+    @Override
+    public Expirable process(final Map.Entry<Object, Expirable> entry) {
+        Expirable expirable = entry.getValue();
+
+        if (expirable == null) {
+            expirable = new ExpiryMarker(version, timeout, nextMarkerId);
+        } else {
+            expirable = expirable.markForExpiration(timeout, nextMarkerId);
+        }
+
+        entry.setValue(expirable);
+
+        return expirable;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeUTF(nextMarkerId);
+        out.writeLong(timeout);
+        out.writeObject(version);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        nextMarkerId = in.readUTF();
+        timeout = in.readLong();
+        version = in.readObject();
+    }
+
+    @Override
+    public int getId() {
+        return HibernateDataSerializerHook.LOCK;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A concrete implementation of {@link com.hazelcast.map.EntryProcessor} which unlocks
+ * a soft-locked region cached entry
+ *
+ * @since 3.7
+ */
+public class UnlockEntryProcessor extends AbstractRegionCacheEntryProcessor {
+
+    private ExpiryMarker lock;
+    private String nextMarkerId;
+    private long timestamp;
+
+    public UnlockEntryProcessor() {
+    }
+
+    public UnlockEntryProcessor(final ExpiryMarker lock, final String nextMarkerId, final long timestamp) {
+        this.lock = lock;
+        this.nextMarkerId = nextMarkerId;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public Void process(final Map.Entry<Object, Expirable> entry) {
+        Expirable expirable = entry.getValue();
+
+        if (expirable != null) {
+            if (expirable.matches(lock)) {
+                expirable = ((ExpiryMarker) expirable).expire(timestamp);
+            } else if (expirable.getValue() != null) {
+                // It's a value. Expire the value immediately. This prevents
+                // in-flight transactions from adding stale values to the cache
+                expirable = new ExpiryMarker(null, timestamp, nextMarkerId).expire(timestamp);
+            } else {
+                // It's a different marker. Leave it alone.
+                return null;
+            }
+            entry.setValue(expirable);
+        }
+
+        return null;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(lock);
+        out.writeUTF(nextMarkerId);
+        out.writeLong(timestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        lock = in.readObject();
+        nextMarkerId = in.readUTF();
+        timestamp = in.readLong();
+    }
+
+    @Override
+    public int getId() {
+        return HibernateDataSerializerHook.UNLOCK;
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A concrete implementation of {@link com.hazelcast.map.EntryProcessor} which attempts
+ * to update a region cache entry
+ *
+ * @since 3.7
+ */
+public class UpdateEntryProcessor extends AbstractRegionCacheEntryProcessor {
+
+    private ExpiryMarker lock;
+    private Object newValue;
+    private Object newVersion;
+    private String nextMarkerId;
+    private long timestamp;
+
+    public UpdateEntryProcessor() {
+    }
+
+    public UpdateEntryProcessor(final ExpiryMarker lock, final Object newValue, final Object newVersion,
+                                final String nextMarkerId, final long timestamp) {
+        this.lock = lock;
+        this.nextMarkerId = nextMarkerId;
+        this.newValue = newValue;
+        this.newVersion = newVersion;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public Boolean process(final Map.Entry<Object, Expirable> entry) {
+        Expirable expirable = entry.getValue();
+        boolean updated;
+
+        if (expirable == null) {
+            // Nothing there. The entry was evicted? It should be safe to replace it
+            expirable = new Value(newVersion, timestamp, newValue);
+            updated = true;
+        } else {
+            if (expirable.matches(lock)) {
+                final ExpiryMarker marker = (ExpiryMarker) expirable;
+                if (marker.isConcurrent()) {
+                    // Multiple transactions are attempting to update the same entry. Its highly
+                    // likely that the value we are attempting to set is invalid. Instead just
+                    // expire the entry and allow the next put to the cache to succeed if no more
+                    // transactions are in-flight.
+                    expirable = marker.expire(timestamp);
+                    updated = false;
+                } else {
+                    // Only one transaction attempted to update the entry so it is safe to replace
+                    // it with the value supplied
+                    expirable = new Value(newVersion, timestamp, newValue);
+                    updated = true;
+                }
+            } else if (expirable.getValue() == null) {
+                // It's a different marker, Leave it as is
+                return false;
+            } else {
+                // It's a value. We have no way to see which is correct so we expire the entry.
+                // It is expired instead of removed to prevent in progress transactions from
+                // putting stale values into the cache
+                expirable = new ExpiryMarker(newVersion, timestamp, nextMarkerId).expire(timestamp);
+                updated = false;
+            }
+        }
+
+        entry.setValue(expirable);
+        return updated;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(lock);
+        out.writeObject(newValue);
+        out.writeObject(newVersion);
+        out.writeUTF(nextMarkerId);
+        out.writeLong(timestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        lock = in.readObject();
+        newValue = in.readObject();
+        newVersion = in.readObject();
+        nextMarkerId = in.readUTF();
+        timestamp = in.readLong();
+    }
+
+    @Override
+    public int getId() {
+        return HibernateDataSerializerHook.UPDATE;
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/package-info.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides distributed class for Hibernate.
+ * such as IMapRegionCache.
+ */
+package com.hazelcast.hibernate.distributed;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.AbstractHazelcastCacheRegionFactory;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+/**
+ * Access underlying HazelcastInstance using Hibernate SessionFactory
+ *
+ * @deprecated Set instanceName for your Hazelcast instance and use
+ *             {@link com.hazelcast.core.Hazelcast#getHazelcastInstanceByName(String instanceName)} instead
+ * @since 3.7
+ */
+@Deprecated
+@SuppressWarnings("deprecation")
+public final class HazelcastAccessor {
+
+    static final ILogger LOGGER = Logger.getLogger(HazelcastAccessor.class);
+
+    private HazelcastAccessor() {
+    }
+
+    /**
+     * Tries to extract <code>HazelcastInstance</code> from <code>Session</code>.
+     *
+     * @param session the {@code Session} to retrieve the Hazelcast instance for
+     * @return Currently used <code>HazelcastInstance</code> or null if an error occurs.
+     */
+    public static HazelcastInstance getHazelcastInstance(final Session session) {
+        return getHazelcastInstance(session.getSessionFactory());
+    }
+
+    /**
+     * Tries to extract <code>HazelcastInstance</code> from <code>SessionFactory</code>.
+     *
+     * @param sessionFactory the {@code SessionFactory} to retrieve the Hazelcast instance for
+     * @return Currently used <code>HazelcastInstance</code> or null if an error occurs.
+     */
+    public static HazelcastInstance getHazelcastInstance(final SessionFactory sessionFactory) {
+        if (!(sessionFactory instanceof SessionFactoryImplementor)) {
+            LOGGER.warning("SessionFactory is expected to be instance of SessionFactoryImplementor.");
+            return null;
+        }
+        return getHazelcastInstance((SessionFactoryImplementor) sessionFactory);
+    }
+
+    /**
+     * Tries to extract <code>HazelcastInstance</code> from <code>SessionFactoryImplementor</code>.
+     *
+     * @param sessionFactory the {@code SessionFactoryImplementor} to retrieve the Hazelcast instance for
+     * @return currently used <code>HazelcastInstance</code> or null if an error occurs.
+     */
+    public static HazelcastInstance getHazelcastInstance(final SessionFactoryImplementor sessionFactory) {
+        final RegionFactory rf = sessionFactory.getSessionFactoryOptions()
+                .getServiceRegistry().getService(RegionFactory.class);
+        if (rf instanceof AbstractHazelcastCacheRegionFactory) {
+            return ((AbstractHazelcastCacheRegionFactory) rf).getHazelcastInstance();
+        } else {
+            LOGGER.warning("Current 2nd level cache implementation is not HazelcastCacheRegionFactory!");
+        }
+        return null;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import org.hibernate.cache.CacheException;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * A factory implementation to build up a {@link com.hazelcast.core.HazelcastInstance}
+ * implementation using {@link com.hazelcast.client.HazelcastClient}.
+ *
+ * @since 3.7
+ */
+class HazelcastClientLoader implements IHazelcastInstanceLoader {
+
+    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+
+    private HazelcastInstance client;
+    private ClientConfig clientConfig;
+
+    @Override
+    public void configure(final Properties props) {
+
+        String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
+        String group = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+        String pass = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
+        String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+
+        if (configResourcePath != null) {
+            try {
+                clientConfig = new XmlClientConfigBuilder(configResourcePath).build();
+            } catch (IOException e) {
+                throw new HazelcastException("Could not load client configuration: " + configResourcePath, e);
+            }
+        } else {
+            clientConfig = new ClientConfig();
+        }
+
+        if (group != null) {
+            clientConfig.getGroupConfig().setName(group);
+        }
+        if (pass != null) {
+            clientConfig.getGroupConfig().setPassword(pass);
+        }
+        if (address != null) {
+            clientConfig.getNetworkConfig().addAddress(address);
+        }
+
+        clientConfig.getNetworkConfig().setSmartRouting(true);
+        clientConfig.getNetworkConfig().setRedoOperation(true);
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+    }
+
+    @Override
+    public HazelcastInstance loadInstance() throws CacheException {
+        client = HazelcastClient.newHazelcastClient(clientConfig);
+        return client;
+    }
+
+    @Override
+    public void unloadInstance() throws CacheException {
+        if (client == null) {
+            return;
+        }
+
+        try {
+            client.getLifecycleService().shutdown();
+            client = null;
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.hibernate.CacheEnvironment;
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+/**
+ * A factory class to build up implementations of {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader}
+ * that returns a {@link com.hazelcast.core.HazelcastInstance} depending on configuration either backed by Hazelcast
+ * client or node implementation.
+ *
+ * @since 3.7
+ */
+public final class HazelcastInstanceFactory {
+
+    private static final String HZ_CLIENT_LOADER_CLASSNAME = "com.hazelcast.hibernate.instance.HazelcastClientLoader";
+    private static final String HZ_INSTANCE_LOADER_CLASSNAME = "com.hazelcast.hibernate.instance.HazelcastInstanceLoader";
+
+    private HazelcastInstanceFactory() {
+    }
+
+    public static IHazelcastInstanceLoader createInstanceLoader(final Properties props) throws CacheException {
+        try {
+            IHazelcastInstanceLoader instanceLoader = (IHazelcastInstanceLoader) props.
+                    get("com.hazelcast.hibernate.instance.loader");
+            if (instanceLoader != null) {
+                return instanceLoader;
+            }
+            Class loaderClass = getInstanceLoaderClass(props);
+            instanceLoader = (IHazelcastInstanceLoader) loaderClass.newInstance();
+            instanceLoader.configure(props);
+            return instanceLoader;
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+
+    private static Class getInstanceLoaderClass(final Properties props) throws ClassNotFoundException {
+        boolean useNativeClient = false;
+        if (props != null) {
+            useNativeClient = CacheEnvironment.isNativeClient(props);
+        }
+        Class loaderClass;
+        ClassLoader cl = HazelcastInstanceFactory.class.getClassLoader();
+        if (useNativeClient) {
+            loaderClass = cl.loadClass(HZ_CLIENT_LOADER_CLASSNAME);
+        } else {
+            loaderClass = cl.loadClass(HZ_INSTANCE_LOADER_CLASSNAME);
+        }
+        return loaderClass;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigLoader;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.util.StringUtil;
+import org.hibernate.cache.CacheException;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * A factory implementation to build up a {@link com.hazelcast.core.HazelcastInstance}
+ * implementation using {@link com.hazelcast.core.Hazelcast}.
+ *
+ * @since 3.7
+ */
+class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
+
+    private static final ILogger LOGGER = Logger.getLogger(HazelcastInstanceFactory.class);
+
+    private HazelcastInstance instance;
+    private Config config;
+    private boolean shutDown;
+
+    @Override
+    public void configure(final Properties props) {
+        String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+        if (!StringUtil.isNullOrEmptyAfterTrim(configResourcePath)) {
+            try {
+                this.config = ConfigLoader.load(configResourcePath);
+            } catch (IOException e) {
+                LOGGER.warning("IOException: " + e.getMessage());
+            }
+            if (config == null) {
+                throw new CacheException("Could not find configuration file: " + configResourcePath);
+            }
+        } else {
+            this.config = new XmlConfigBuilder().build();
+        }
+
+        String instanceName = CacheEnvironment.getInstanceName(props);
+
+        if (instanceName != null) {
+            config.setInstanceName(instanceName);
+        }
+
+        this.shutDown = CacheEnvironment.shutdownOnStop(props, (instanceName == null));
+
+    }
+
+    @Override
+    public HazelcastInstance loadInstance() throws CacheException {
+        if (config.getInstanceName() == null) {
+            instance = Hazelcast.newHazelcastInstance(config);
+        } else {
+            instance = Hazelcast.getOrCreateHazelcastInstance(config);
+        }
+        return instance;
+    }
+
+    @Override
+    public void unloadInstance() throws CacheException {
+        if (instance == null) {
+            return;
+        }
+        if (!shutDown) {
+            LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
+                    + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
+                    + GroupProperty.SHUTDOWNHOOK_ENABLED + " property!)");
+            return;
+        }
+        try {
+            instance.getLifecycleService().shutdown();
+            instance = null;
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceLoader.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceLoader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+/**
+ * Factory interface to build Hazelcast instances and configure them depending
+ * on configuration.
+ *
+ * @since 3.7
+ */
+public interface IHazelcastInstanceLoader {
+
+    /**
+     * Applies a set of properties to the factory
+     *
+     * @param props properties to apply
+     */
+    void configure(final Properties props);
+
+    /**
+     * Create a new {@link com.hazelcast.core.HazelcastInstance} or loads an already
+     * existing instances by it's name.
+     *
+     * @return new or existing HazelcastInstance (either client or node mode)
+     * @throws CacheException all exceptions wrapped to CacheException
+     */
+    HazelcastInstance loadInstance() throws CacheException;
+
+    /**
+     * Tries to shutdown a HazelcastInstance
+     *
+     * @throws CacheException all exceptions wrapped to CacheException
+     */
+    void unloadInstance() throws CacheException;
+}
+

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/package-info.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides instance interfaces/classes for Hibernate.
+ */
+package com.hazelcast.hibernate.instance;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+
+import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An internal service to clean cache regions
+ *
+ * @since 3.7
+ */
+public final class CleanupService {
+
+    private static final long FIXED_DELAY = 60;
+    private static final long FIXED_DELAY1 = 60;
+
+    private final String name;
+    private final ScheduledExecutorService executor;
+
+    public CleanupService(final String name) {
+        this.name = name;
+        executor = Executors.newSingleThreadScheduledExecutor(new CleanupThreadFactory());
+    }
+
+    public void registerCache(final LocalRegionCache cache) {
+        executor.scheduleWithFixedDelay(new Runnable() {
+
+            @Override
+            public void run() {
+                cache.cleanup();
+            }
+        }, FIXED_DELAY, FIXED_DELAY1, TimeUnit.SECONDS);
+    }
+
+    public void stop() {
+        executor.shutdownNow();
+    }
+
+    /**
+     * Internal ThreadFactory to create cleanup threads
+     */
+    private class CleanupThreadFactory implements ThreadFactory {
+
+        @Override
+        public Thread newThread(final Runnable r) {
+            final Thread thread = new CleanupThread(r, name + ".hibernate.cleanup");
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+
+    /**
+     * Runnable thread adapter to capture exceptions and notify Hazelcast about them
+     */
+    private static final class CleanupThread extends Thread {
+
+        private CleanupThread(final Runnable target, final String name) {
+            super(target, name);
+        }
+
+        @Override
+        public void run() {
+            try {
+                super.run();
+            } catch (OutOfMemoryError e) {
+                OutOfMemoryErrorDispatcher.onOutOfMemory(e);
+            }
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * An invalidation messages
+ *
+ * @since 3.7
+ */
+public class Invalidation implements IdentifiedDataSerializable {
+
+    private Object key;
+    private Object version;
+
+    public Invalidation() {
+    }
+
+    public Invalidation(final Object key, final Object version) {
+        this.key = key;
+        this.version = version;
+    }
+
+    public Object getKey() {
+        return key;
+    }
+
+    public Object getVersion() {
+        return version;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(key);
+        out.writeObject(version);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        key = in.readObject();
+        version = in.readObject();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return HibernateDataSerializerHook.INVALIDATION;
+    }
+
+    @Override
+    public String toString() {
+        return "Invalidation{key=" + key + ", version=" + version + '}';
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.Message;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.hibernate.HazelcastTimestamper;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.MarkerWrapper;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.util.Clock;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Local only {@link com.hazelcast.hibernate.RegionCache} implementation
+ * based on a topic to distribute cache updates.
+ *
+ * @since 3.7
+ */
+public class LocalRegionCache implements RegionCache {
+
+    private static final long SEC_TO_MS = 1000L;
+    private static final int MAX_SIZE = 100000;
+    private static final float BASE_EVICTION_RATE = 0.2F;
+
+    protected final HazelcastInstance hazelcastInstance;
+    protected final ITopic<Object> topic;
+    protected final MessageListener<Object> messageListener;
+    protected final ConcurrentMap<Object, Expirable> cache;
+    protected final Comparator versionComparator;
+    protected final AtomicLong markerIdCounter;
+    protected MapConfig config;
+
+    private final ILogger log = Logger.getLogger(LocalRegionCache.class);
+
+    /**
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with (optional)
+     * @param metadata          metadata describing the cached data, used to compare data versions (optional)
+     */
+    public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                            final CacheDataDescription metadata) {
+        this(name, hazelcastInstance, metadata, true);
+    }
+
+    /**
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with if {@code withTopic} is {@code true} (optional)
+     * @param metadata          metadata describing the cached data, used to compare data versions (optional)
+     * @param withTopic         {@code true} to register a {@link MessageListener} with the {@link ITopic} whose name
+     *                          matches this region cache <i>if</i> a {@code HazelcastInstance} was provided to look
+     *                          up the topic; otherwise, {@code false} not to register a listener even if an instance
+     *                          was provided
+     */
+    public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                            final CacheDataDescription metadata, final boolean withTopic) {
+        this.hazelcastInstance = hazelcastInstance;
+        try {
+            config = hazelcastInstance != null ? hazelcastInstance.getConfig().findMapConfig(name) : null;
+        } catch (UnsupportedOperationException e) {
+            log.finest(e);
+        }
+        versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
+        cache = new ConcurrentHashMap<Object, Expirable>();
+        markerIdCounter = new AtomicLong();
+
+        messageListener = createMessageListener();
+        if (withTopic && hazelcastInstance != null) {
+            topic = hazelcastInstance.getTopic(name);
+            topic.addMessageListener(messageListener);
+        } else {
+            topic = null;
+        }
+    }
+
+    @Override
+    public Object get(final Object key, long txTimestamp) {
+        final Expirable value = cache.get(key);
+        return value == null ? null : value.getValue(txTimestamp);
+    }
+
+    @Override
+    public boolean insert(final Object key, final Object value, final Object currentVersion) {
+        final Value newValue = new Value(currentVersion, nextTimestamp(), value);
+        return cache.putIfAbsent(key, newValue) == null;
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        while (true) {
+            Expirable previous = cache.get(key);
+            Value newValue = new Value(version, nextTimestamp(), value);
+            if (previous == null) {
+                if (cache.putIfAbsent(key, newValue) == null) {
+                    return true;
+                }
+            } else if (previous.isReplaceableBy(txTimestamp, version, versionComparator)) {
+                if (cache.replace(key, previous, newValue)) {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+
+    @Override
+    public boolean update(final Object key, final Object newValue, final Object newVersion, final SoftLock softLock) {
+        boolean updated = false;
+        while (true) {
+            Expirable original = cache.get(key);
+            Expirable revised;
+            long timestamp = nextTimestamp();
+            if (original == null) {
+                // The entry must have expired. it should be safe to update
+                revised = new Value(newVersion, timestamp, newValue);
+                updated = true;
+                if (cache.putIfAbsent(key, revised) == null) {
+                    break;
+                }
+            } else {
+                if (softLock instanceof MarkerWrapper) {
+                    final ExpiryMarker unwrappedMarker = ((MarkerWrapper) softLock).getMarker();
+                    if (original.matches(unwrappedMarker)) {
+                        // The lock matches
+                        final ExpiryMarker marker = (ExpiryMarker) original;
+                        if (marker.isConcurrent()) {
+                            revised = marker.expire(timestamp);
+                            updated = false;
+                        } else {
+                            revised = new Value(newVersion, timestamp, newValue);
+                            updated = true;
+                        }
+                        if (cache.replace(key, original, revised)) {
+                            break;
+                        }
+                    } else if (original.getValue() == null) {
+                        // It's marked for expiration, leave it as is
+                        updated = false;
+                        break;
+                    } else {
+                        // It's a value. Instead of removing it, expire it to prevent stale from in progress
+                        // transactions being put in the cache
+                        revised = new ExpiryMarker(newVersion, timestamp, nextMarkerId()).expire(timestamp);
+                        updated = false;
+                        if (cache.replace(key, original, revised)) {
+                            break;
+                        }
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        maybeNotifyTopic(key, newValue, newVersion);
+
+        return updated;
+    }
+
+    protected void maybeNotifyTopic(final Object key, final Object value, final Object version) {
+        if (topic != null) {
+            topic.publish(createMessage(key, value, version));
+        }
+    }
+
+    protected Object createMessage(final Object key, final Object value, final Object currentVersion) {
+        return new Invalidation(key, currentVersion);
+    }
+
+    protected MessageListener<Object> createMessageListener() {
+        return new MessageListener<Object>() {
+
+            @Override
+            public void onMessage(final Message<Object> message) {
+                if (!message.getPublishingMember().localMember()) {
+                    maybeInvalidate(message.getMessageObject());
+                }
+            }
+        };
+    }
+
+    @Override
+    public boolean remove(final Object key) {
+        final Expirable value = cache.remove(key);
+        maybeNotifyTopic(key, null, (value == null) ? null : value.getVersion());
+        return (value != null);
+    }
+
+    @Override
+    public SoftLock tryLock(final Object key, final Object version) {
+        ExpiryMarker marker;
+        String markerId = nextMarkerId();
+        while (true) {
+            final Expirable original = cache.get(key);
+            long timeout = nextTimestamp() + CacheEnvironment.getDefaultCacheTimeoutInMillis();
+            if (original == null) {
+                marker = new ExpiryMarker(version, timeout, markerId);
+                if (cache.putIfAbsent(key, marker) == null) {
+                    break;
+                }
+            } else {
+                marker = original.markForExpiration(timeout, markerId);
+                if (cache.replace(key, original, marker)) {
+                    break;
+                }
+            }
+        }
+        return new MarkerWrapper(marker);
+    }
+
+    @Override
+    public void unlock(final Object key, final SoftLock lock) {
+        while (true) {
+            final Expirable original = cache.get(key);
+            if (original != null) {
+                if (!(lock instanceof MarkerWrapper)) {
+                    break;
+                }
+                final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+                if (original.matches(unwrappedMarker)) {
+                    final Expirable revised = ((ExpiryMarker) original).expire(nextTimestamp());
+                    if (cache.replace(key, original, revised)) {
+                        break;
+                    }
+                } else if (original.getValue() != null) {
+                    if (cache.remove(key, original)) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        maybeNotifyTopic(key, null, null);
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return cache.containsKey(key);
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+        maybeNotifyTopic(null, null, null);
+    }
+
+    @Override
+    public long size() {
+        return cache.size();
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        return 0;
+    }
+
+    @Override
+    public Map asMap() {
+        return cache;
+    }
+
+    void cleanup() {
+        final int maxSize;
+        final long timeToLive;
+        if (config != null) {
+            maxSize = config.getMaxSizeConfig().getSize();
+            timeToLive = config.getTimeToLiveSeconds() * SEC_TO_MS;
+        } else {
+            maxSize = MAX_SIZE;
+            timeToLive = CacheEnvironment.getDefaultCacheTimeoutInMillis();
+        }
+
+        boolean limitSize = maxSize > 0 && maxSize != Integer.MAX_VALUE;
+        if (limitSize || timeToLive > 0) {
+            List<EvictionEntry> entries = searchEvictableEntries(timeToLive, limitSize);
+            final int diff = cache.size() - maxSize;
+            final int evictionRate = calculateEvictionRate(diff, maxSize);
+            if (evictionRate > 0 && entries != null) {
+                evictEntries(entries, evictionRate);
+            }
+        }
+    }
+
+    protected void maybeInvalidate(final Object messageObject) {
+        Invalidation invalidation = (Invalidation) messageObject;
+        Object key = invalidation.getKey();
+        if (key == null) {
+            // Invalidate the entire region cache.
+            cache.clear();
+        } else if (versionComparator == null) {
+            // For an unversioned entity or collection we can only invalidate the entry.
+            cache.remove(key);
+        } else {
+            // For versioned entities we can avoid the invalidation if both we and the remote node know the version,
+            // AND our version is definitely equal or higher.  Otherwise, we have to just invalidate our entry.
+            final Expirable value = cache.get(key);
+            if (value != null) {
+                maybeInvalidateVersionedEntity(key, value, invalidation.getVersion());
+            }
+        }
+    }
+
+    private void maybeInvalidateVersionedEntity(final Object key, final Expirable value, final Object newVersion) {
+        if (newVersion == null) {
+            // This invalidation was for an entity with unknown version.  Just invalidate the entry
+            // unconditionally.
+            cache.remove(key);
+        } else {
+            // Invalidate our entry only if it was of a lower version.
+            Object currentVersion = value.getVersion();
+            if (versionComparator.compare(currentVersion, newVersion) < 0) {
+                cache.remove(key, value);
+            }
+        }
+    }
+
+    private String nextMarkerId() {
+        return Long.toString(markerIdCounter.getAndIncrement());
+    }
+
+    private long nextTimestamp() {
+        return hazelcastInstance == null ? Clock.currentTimeMillis()
+                : HazelcastTimestamper.nextTimestamp(hazelcastInstance);
+    }
+
+    private List<EvictionEntry> searchEvictableEntries(final long timeToLive, final boolean limitSize) {
+        List<EvictionEntry> entries = null;
+        Iterator<Entry<Object, Expirable>> iter = cache.entrySet().iterator();
+        long now = nextTimestamp();
+        while (iter.hasNext()) {
+            final Entry<Object, Expirable> e = iter.next();
+            final Object k = e.getKey();
+            final Expirable expirable = e.getValue();
+            if (expirable instanceof ExpiryMarker) {
+                continue;
+            }
+            final Value v = (Value) expirable;
+            if (timeToLive > 0 && v.getTimestamp() + timeToLive < now) {
+                iter.remove();
+            } else if (limitSize) {
+                if (entries == null) {
+                    // Use a List rather than a Set for correctness. Using a Set, especially a TreeSet
+                    // based on EvictionEntry.compareTo, causes evictions to be processed incorrectly
+                    // when two or more entries in the map have the same timestamp. In such a case, the
+                    // _first_ entry at a given timestamp is the only one that can be evicted because
+                    // TreeSet does not add "equivalent" entries. A second benefit of using a List is
+                    // that the cost of sorting the entries is not incurred if eviction isn't performed
+                    entries = new ArrayList<EvictionEntry>(cache.size());
+                }
+                entries.add(new EvictionEntry(k, v));
+            }
+        }
+        return entries;
+    }
+
+    private int calculateEvictionRate(final int diff, final int maxSize) {
+        return diff >= 0 ? (diff + (int) (maxSize * BASE_EVICTION_RATE)) : 0;
+    }
+
+    private void evictEntries(final List<EvictionEntry> entries, final int evictionRate) {
+        // Only sort the entries if we're going to evict some
+        Collections.sort(entries);
+        int removed = 0;
+        for (EvictionEntry entry : entries) {
+            if (cache.remove(entry.key, entry.value) && ++removed == evictionRate) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Inner class that instances represent an entry marked for eviction
+     */
+    private static final class EvictionEntry implements Comparable<EvictionEntry> {
+        final Object key;
+        final Value value;
+
+        private EvictionEntry(final Object key, final Value value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(final EvictionEntry o) {
+            final long thisVal = this.value.getTimestamp();
+            final long anotherVal = o.value.getTimestamp();
+            return (thisVal < anotherVal ? -1 : (thisVal == anotherVal ? 0 : 1));
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            EvictionEntry that = (EvictionEntry) o;
+
+            return (key == null ? that.key == null : key.equals(that.key))
+                    && (value == null ? that.value == null : value.equals(that.value));
+        }
+
+        @Override
+        public int hashCode() {
+            return key == null ? 0 : key.hashCode();
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * Hazelcast compatible implementation of a timestamp for internal eviction
+ *
+ * @since 3.7
+ */
+public class Timestamp implements IdentifiedDataSerializable {
+
+    private Object key;
+    private long timestamp;
+
+    public Timestamp() {
+    }
+
+    public Timestamp(final Object key, final long timestamp) {
+        this.key = key;
+        this.timestamp = timestamp;
+    }
+
+    public Object getKey() {
+        return key;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(key);
+        out.writeLong(timestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        key = in.readObject();
+        timestamp = in.readLong();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return HibernateDataSerializerHook.TIMESTAMP;
+    }
+
+    @Override
+    public String toString() {
+        return "Timestamp" + "{key=" + key + ", timestamp=" + timestamp + '}';
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.util.Clock;
+
+/**
+ * A timestamp based local RegionCache
+ *
+ * @since 3.7
+ */
+public class TimestampsRegionCache extends LocalRegionCache implements RegionCache {
+
+    public TimestampsRegionCache(final String name, final HazelcastInstance hazelcastInstance) {
+        super(name, hazelcastInstance, null);
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        boolean succeed = super.put(key, value, (Long) value, version);
+        if (succeed) {
+            maybeNotifyTopic(key, value, version);
+        }
+        return succeed;
+    }
+
+    @Override
+    protected void maybeInvalidate(final Object messageObject) {
+        final Timestamp ts = (Timestamp) messageObject;
+        final Object key = ts.getKey();
+
+        for (;;) {
+            final Expirable value = cache.get(key);
+            final Long current = value != null ? (Long) value.getValue() : null;
+            if (current != null) {
+                if (ts.getTimestamp() > current) {
+                    if (cache.replace(key, value, new Value(value.getVersion(),
+                            Clock.currentTimeMillis(), ts.getTimestamp()))) {
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            } else {
+                if (cache.putIfAbsent(key, new Value(null, Clock.currentTimeMillis(),
+                        ts.getTimestamp())) == null) {
+                    return;
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Object createMessage(final Object key, final Object value, final Object currentVersion) {
+        return new Timestamp(key, (Long) value);
+    }
+
+    @Override
+    final void cleanup() {
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/package-info.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides local classes for Hibernate.
+ * such as TimeStamp,CleanupService.
+ */
+package com.hazelcast.hibernate.local;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/package-info.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains interfaces/classes related to Hibernate.
+ */
+package com.hazelcast.hibernate;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/AbstractGeneralRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/AbstractGeneralRegion.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.GeneralDataRegion;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.util.Properties;
+
+/**
+ * Basic implementation of a IMap based cache without any special security checks
+ *
+ * @param <Cache> implementation type of RegionCache
+ * @since 3.7
+ */
+abstract class AbstractGeneralRegion<Cache extends RegionCache>
+        extends AbstractHazelcastRegion<Cache>
+        implements GeneralDataRegion {
+
+    private final Cache cache;
+
+    protected AbstractGeneralRegion(final HazelcastInstance instance, final String name,
+                                    final Properties props, final Cache cache) {
+        super(instance, name, props);
+        this.cache = cache;
+    }
+
+    @Override
+    public void evict(final Object key) throws CacheException {
+        try {
+            getCache().remove(key);
+        } catch (OperationTimeoutException e) {
+            Logger.getLogger(AbstractGeneralRegion.class).finest(e);
+        }
+    }
+
+    @Override
+    public void evictAll() throws CacheException {
+        try {
+            getCache().clear();
+        } catch (OperationTimeoutException e) {
+            Logger.getLogger(AbstractGeneralRegion.class).finest(e);
+        }
+    }
+
+    @Override
+    public Object get(final SessionImplementor session, final Object key) throws CacheException {
+        try {
+            return getCache().get(key, nextTimestamp());
+        } catch (OperationTimeoutException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void put(final SessionImplementor session, final Object key, final Object value) throws CacheException {
+        try {
+            getCache().put(key, value, nextTimestamp(), null);
+        } catch (OperationTimeoutException e) {
+            Logger.getLogger(AbstractGeneralRegion.class).finest(e);
+        }
+    }
+
+    @Override
+    public Cache getCache() {
+        return cache;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/AbstractHazelcastRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/AbstractHazelcastRegion.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.HazelcastTimestamper;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Abstract superclass of Hazelcast region of Hibernate caches
+ *
+ * @param <Cache> implementation type of RegionCache
+ * @since 3.7
+ */
+abstract class AbstractHazelcastRegion<Cache extends RegionCache> implements HazelcastRegion<Cache> {
+
+    protected final Properties props;
+    private final HazelcastInstance instance;
+    private final String regionName;
+    private final int timeout;
+
+    protected AbstractHazelcastRegion(final HazelcastInstance instance, final String regionName, final Properties props) {
+        this.instance = instance;
+        this.regionName = regionName;
+        this.timeout = HazelcastTimestamper.getTimeout(instance, regionName);
+        this.props = props;
+    }
+
+    @Override
+    public void destroy() throws CacheException {
+        // Destroy of the region should not propagate
+        // to other nodes of cluster.
+        // Do nothing on destroy.
+    }
+
+    /**
+     * @return The size of the internal <code>{@link com.hazelcast.core.IMap}</code>.
+     */
+    @Override
+    public long getElementCountInMemory() {
+        return getCache().size();
+    }
+
+    /**
+     * Hazelcast does not support pushing elements to disk.
+     *
+     * @return -1 this value means "unsupported"
+     */
+    @Override
+    public long getElementCountOnDisk() {
+        return -1;
+    }
+
+    /**
+     * @return The name of the region.
+     */
+    @Override
+    public String getName() {
+        return regionName;
+    }
+
+    /**
+     * @return a rough estimate of number of bytes used by this region.
+     */
+    @Override
+    public long getSizeInMemory() {
+        return getCache().getSizeInMemory();
+    }
+
+    @Override
+    public final int getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public final long nextTimestamp() {
+        return HazelcastTimestamper.nextTimestamp(instance);
+    }
+
+    /**
+     * Appears to be used only by <code>org.hibernate.stat.SecondLevelCacheStatistics</code>.
+     *
+     * @return the internal <code>IMap</code> used for this region.
+     */
+    @Override
+    public Map toMap() {
+        return getCache().asMap();
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return getCache().contains(key);
+    }
+
+    @Override
+    public final HazelcastInstance getInstance() {
+        return instance;
+    }
+
+    @Override
+    public final ILogger getLogger() {
+        final String name = getClass().getName();
+        try {
+            return instance.getLoggingService().getLogger(name);
+        } catch (UnsupportedOperationException e) {
+            // HazelcastInstance is instance of HazelcastClient.
+            return Logger.getLogger(name);
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/AbstractTransactionalDataRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/AbstractTransactionalDataRegion.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.TransactionalDataRegion;
+
+import java.util.Properties;
+
+/**
+ * Abstract base class of all regions
+ *
+ * @param <Cache> implementation type of RegionCache
+ * @since 3.7
+ */
+public abstract class AbstractTransactionalDataRegion<Cache extends RegionCache>
+        extends AbstractHazelcastRegion<Cache>
+        implements TransactionalDataRegion {
+
+    private final CacheDataDescription metadata;
+    private final Cache cache;
+
+    protected AbstractTransactionalDataRegion(final HazelcastInstance instance, final String regionName,
+                                              final Properties props, final CacheDataDescription metadata,
+                                              final Cache cache) {
+        super(instance, regionName, props);
+        this.metadata = metadata;
+        this.cache = cache;
+    }
+
+    @Override
+    public CacheDataDescription getCacheDataDescription() {
+        return metadata;
+    }
+
+    @Override
+    public boolean isTransactionAware() {
+        return false;
+    }
+
+    @Override
+    public Cache getCache() {
+        return cache;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.hibernate.access.AccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.CollectionRegion;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
+
+/**
+ * Simple adapter implementation for transactional / concurrent access control on collections
+ *
+ * @since 3.7
+ */
+public final class CollectionRegionAccessStrategyAdapter implements CollectionRegionAccessStrategy {
+
+    private final AccessDelegate<? extends HazelcastCollectionRegion> delegate;
+
+    public CollectionRegionAccessStrategyAdapter(final AccessDelegate<? extends HazelcastCollectionRegion> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void evict(final Object key) throws CacheException {
+        delegate.evict(key);
+    }
+
+    @Override
+    public void evictAll() throws CacheException {
+        delegate.evictAll();
+    }
+
+    @Override
+    public Object generateCacheKey(final Object id, final CollectionPersister persister,
+                                   final SessionFactoryImplementor session, final String tenantIdentifier) {
+        return DefaultCacheKeysFactory.createCollectionKey(id, persister, session, tenantIdentifier);
+    }
+
+    @Override
+    public Object get(final SessionImplementor session, final Object key, final long txTimestamp)
+            throws CacheException {
+        return delegate.get(key, txTimestamp);
+    }
+
+    @Override
+    public Object getCacheKeyId(final Object cacheKey) {
+        return DefaultCacheKeysFactory.getCollectionId(cacheKey);
+    }
+
+    @Override
+    public CollectionRegion getRegion() {
+        return delegate.getHazelcastRegion();
+    }
+
+    @Override
+    public SoftLock lockItem(final SessionImplementor session, final Object key, final Object version)
+            throws CacheException {
+        return delegate.lockItem(key, version);
+    }
+
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        return delegate.lockRegion();
+    }
+
+    @Override
+    public boolean putFromLoad(final SessionImplementor session, final Object key, final Object value,
+                               final long txTimestamp, final Object version) throws CacheException {
+        return delegate.putFromLoad(key, value, txTimestamp, version);
+    }
+
+    @Override
+    public boolean putFromLoad(final SessionImplementor session, final Object key, final Object value,
+                               final long txTimestamp, final Object version, final boolean minimalPutOverride)
+            throws CacheException {
+        return delegate.putFromLoad(key, value, txTimestamp, version, minimalPutOverride);
+    }
+
+    @Override
+    public void remove(final SessionImplementor session, final Object key) throws CacheException {
+        delegate.remove(key);
+    }
+
+    @Override
+    public void removeAll() throws CacheException {
+        delegate.removeAll();
+    }
+
+    @Override
+    public void unlockItem(final SessionImplementor session, final Object key, final SoftLock lock)
+            throws CacheException {
+        delegate.unlockItem(key, lock);
+    }
+
+    @Override
+    public void unlockRegion(final SoftLock lock) throws CacheException {
+        delegate.unlockRegion(lock);
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/EntityRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/EntityRegionAccessStrategyAdapter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.hibernate.access.AccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.EntityRegion;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * Simple adapter implementation for transactional / concurrent access control on entities
+ *
+ * @since 3.7
+ */
+public final class EntityRegionAccessStrategyAdapter implements EntityRegionAccessStrategy {
+
+    private final AccessDelegate<? extends HazelcastEntityRegion> delegate;
+
+    public EntityRegionAccessStrategyAdapter(final AccessDelegate<? extends HazelcastEntityRegion> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean afterInsert(final SessionImplementor session, final Object key, final Object value,
+                               final Object version) throws CacheException {
+        return delegate.afterInsert(key, value, version);
+    }
+
+    @Override
+    public boolean afterUpdate(final SessionImplementor session, final Object key, final Object value,
+                               final Object currentVersion, final Object previousVersion, final SoftLock lock)
+            throws CacheException {
+        return delegate.afterUpdate(key, value, currentVersion, previousVersion, lock);
+    }
+
+    @Override
+    public void evict(final Object key) throws CacheException {
+        delegate.evict(key);
+    }
+
+    @Override
+    public void evictAll() throws CacheException {
+        delegate.evictAll();
+    }
+
+    @Override
+    public Object generateCacheKey(final Object id, final EntityPersister persister,
+                                   final SessionFactoryImplementor session, final String tenantIdentifier) {
+        return DefaultCacheKeysFactory.createEntityKey(id, persister, session, tenantIdentifier);
+    }
+
+    @Override
+    public Object get(final SessionImplementor session, final Object key, final long txTimestamp)
+            throws CacheException {
+        return delegate.get(key, txTimestamp);
+    }
+
+    @Override
+    public Object getCacheKeyId(final Object cacheKey) {
+        return DefaultCacheKeysFactory.getEntityId(cacheKey);
+    }
+
+    @Override
+    public EntityRegion getRegion() {
+        return delegate.getHazelcastRegion();
+    }
+
+    @Override
+    public boolean insert(final SessionImplementor session, final Object key, final Object value,
+                          final Object version) throws CacheException {
+        return delegate.insert(key, value, version);
+    }
+
+    @Override
+    public SoftLock lockItem(final SessionImplementor session, final Object key, final Object version)
+            throws CacheException {
+        return delegate.lockItem(key, version);
+    }
+
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        return delegate.lockRegion();
+    }
+
+    @Override
+    public boolean putFromLoad(final SessionImplementor session, final Object key, final Object value,
+                               final long txTimestamp, final Object version) throws CacheException {
+        return delegate.putFromLoad(key, value, txTimestamp, version);
+    }
+
+    @Override
+    public boolean putFromLoad(final SessionImplementor session, final Object key, final Object value,
+                               final long txTimestamp, final Object version, final boolean minimalPutOverride)
+            throws CacheException {
+        return delegate.putFromLoad(key, value, txTimestamp, version, minimalPutOverride);
+    }
+
+    @Override
+    public void remove(final SessionImplementor session, final Object key) throws CacheException {
+        delegate.remove(key);
+    }
+
+    @Override
+    public void removeAll() throws CacheException {
+        delegate.removeAll();
+    }
+
+    @Override
+    public void unlockItem(final SessionImplementor session, final Object key, final SoftLock lock)
+            throws CacheException {
+        delegate.unlockItem(key, lock);
+    }
+
+    @Override
+    public void unlockRegion(final SoftLock lock) throws CacheException {
+        delegate.unlockRegion(lock);
+    }
+
+    @Override
+    public boolean update(final SessionImplementor session, final Object key, final Object value,
+                          final Object currentVersion, final Object previousVersion) throws CacheException {
+        return delegate.update(key, value, currentVersion, previousVersion);
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastCollectionRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastCollectionRegion.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CollectionRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
+
+import java.util.Properties;
+
+/**
+ * An collection region implementation based upon Hazelcast IMap with basic concurrency / transactional support
+ * by supplying CollectionRegionAccessStrategy
+ *
+ * @param <Cache> implementation type of RegionCache
+ * @since 3.7
+ */
+public final class HazelcastCollectionRegion<Cache extends RegionCache> extends AbstractTransactionalDataRegion<Cache>
+        implements CollectionRegion {
+
+    public HazelcastCollectionRegion(final HazelcastInstance instance,
+                                     final String regionName, final Properties props,
+                                     final CacheDataDescription metadata, final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
+    }
+
+    @Override
+    public CollectionRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {
+        if (AccessType.READ_ONLY.equals(accessType)) {
+            return new CollectionRegionAccessStrategyAdapter(
+                    new ReadOnlyAccessDelegate<HazelcastCollectionRegion>(this, props));
+        }
+        if (AccessType.NONSTRICT_READ_WRITE.equals(accessType)) {
+            return new CollectionRegionAccessStrategyAdapter(
+                    new NonStrictReadWriteAccessDelegate<HazelcastCollectionRegion>(this, props));
+        }
+        if (AccessType.READ_WRITE.equals(accessType)) {
+            return new CollectionRegionAccessStrategyAdapter(
+                    new ReadWriteAccessDelegate<HazelcastCollectionRegion>(this, props));
+        }
+        throw new CacheException("AccessType \"" + accessType + "\" is not currently supported by Hazelcast.");
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastEntityRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastEntityRegion.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.EntityRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
+
+import java.util.Properties;
+
+/**
+ * An entity region implementation based upon Hazelcast IMap with basic concurrency / transactional support
+ * by supplying EntityRegionAccessStrategy
+ *
+ * @param <Cache> implementation type of RegionCache
+ * @since 3.7
+ */
+public final class HazelcastEntityRegion<Cache extends RegionCache>
+        extends AbstractTransactionalDataRegion<Cache> implements EntityRegion {
+
+    public HazelcastEntityRegion(final HazelcastInstance instance,
+                                 final String regionName, final Properties props,
+                                 final CacheDataDescription metadata, final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
+    }
+
+    @Override
+    public EntityRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {
+        if (AccessType.READ_ONLY.equals(accessType)) {
+            return new EntityRegionAccessStrategyAdapter(
+                    new ReadOnlyAccessDelegate<HazelcastEntityRegion>(this, props));
+        }
+        if (AccessType.NONSTRICT_READ_WRITE.equals(accessType)) {
+            return new EntityRegionAccessStrategyAdapter(
+                    new NonStrictReadWriteAccessDelegate<HazelcastEntityRegion>(this, props));
+        }
+        if (AccessType.READ_WRITE.equals(accessType)) {
+            return new EntityRegionAccessStrategyAdapter(
+                    new ReadWriteAccessDelegate<HazelcastEntityRegion>(this, props));
+        }
+        throw new CacheException("AccessType \"" + accessType + "\" is not currently supported by Hazelcast.");
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
+import com.hazelcast.hibernate.distributed.IMapRegionCache;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.NaturalIdRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
+
+import java.util.Properties;
+
+/**
+ * Hazelcast based implementation used to store NaturalIds
+ *
+ * @since 3.7
+ */
+public class HazelcastNaturalIdRegion<Cache extends RegionCache>
+        extends AbstractTransactionalDataRegion<Cache>
+        implements NaturalIdRegion {
+
+    public HazelcastNaturalIdRegion(final HazelcastInstance instance, final String regionName,
+                                    final Properties props, final CacheDataDescription metadata,
+                                    final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
+    }
+
+    @Override
+    public NaturalIdRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {
+        if (AccessType.READ_ONLY.equals(accessType)) {
+            return new NaturalIdRegionAccessStrategyAdapter(
+                    new ReadOnlyAccessDelegate<HazelcastNaturalIdRegion>(this, props));
+        }
+        if (AccessType.NONSTRICT_READ_WRITE.equals(accessType)) {
+            return new NaturalIdRegionAccessStrategyAdapter(
+                    new NonStrictReadWriteAccessDelegate<HazelcastNaturalIdRegion>(this, props));
+        }
+        if (AccessType.READ_WRITE.equals(accessType)) {
+            return new NaturalIdRegionAccessStrategyAdapter(
+                    new ReadWriteAccessDelegate<HazelcastNaturalIdRegion>(this, props));
+        }
+        throw new CacheException("AccessType \"" + accessType + "\" is not currently supported by Hazelcast.");
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import org.hibernate.cache.spi.QueryResultsRegion;
+
+import java.util.Properties;
+
+/**
+ * Hazelcast based implementation of a storage region for query results
+ *
+ * @since 3.7
+ */
+public class HazelcastQueryResultsRegion extends AbstractGeneralRegion<LocalRegionCache> implements QueryResultsRegion {
+
+    public HazelcastQueryResultsRegion(final HazelcastInstance instance, final String name, final Properties props) {
+        // Note: The HazelcastInstance _must_ be passed down here. Otherwise query caches
+        // cannot be configured and will always use defaults. However, even though we're
+        // passing the HazelcastInstance, we don't want to use an ITopic for invalidation
+        // because the timestamps cache can take care of outdated queries
+        super(instance, name, props, new LocalRegionCache(name, instance, null, false));
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastRegion.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.logging.ILogger;
+import org.hibernate.cache.spi.Region;
+
+/**
+ * Hazelcast specific interface version of Hibernate's Region
+ *
+ * @param <Cache> implementation type of RegionCache
+ * @since 3.7
+ */
+public interface HazelcastRegion<Cache extends RegionCache> extends Region {
+
+    HazelcastInstance getInstance();
+
+    Cache getCache();
+
+    ILogger getLogger();
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegion.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegion.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import org.hibernate.cache.spi.TimestampsRegion;
+
+import java.util.Properties;
+
+/**
+ * Hazelcast based timestamp using region implementation
+ *
+ * @param <Cache> implementation type of RegionCache
+ * @since 3.7
+ */
+public class HazelcastTimestampsRegion<Cache extends RegionCache>
+        extends AbstractGeneralRegion<Cache> implements TimestampsRegion {
+
+    public HazelcastTimestampsRegion(final HazelcastInstance instance, final String name,
+                                     final Properties props, final Cache cache) {
+        super(instance, name, props, cache);
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/NaturalIdRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/NaturalIdRegionAccessStrategyAdapter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.hibernate.access.AccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.NaturalIdRegion;
+import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * Simple adapter implementation for transactional / concurrent access control on natural ids
+ *
+ * @since 3.7
+ */
+public final class NaturalIdRegionAccessStrategyAdapter implements NaturalIdRegionAccessStrategy {
+
+    private final AccessDelegate<? extends HazelcastNaturalIdRegion> delegate;
+
+    public NaturalIdRegionAccessStrategyAdapter(final AccessDelegate<? extends HazelcastNaturalIdRegion> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean afterInsert(final SessionImplementor session, final Object key, final Object value)
+            throws CacheException {
+        return delegate.afterInsert(key, value, null);
+    }
+
+    @Override
+    public boolean afterUpdate(final SessionImplementor session, final Object key, final Object value,
+                               final SoftLock lock) throws CacheException {
+        return delegate.afterUpdate(key, value, null, null, lock);
+    }
+
+    @Override
+    public void evict(final Object key) throws CacheException {
+        delegate.evict(key);
+    }
+
+    @Override
+    public void evictAll() throws CacheException {
+        delegate.evictAll();
+    }
+
+    @Override
+    public Object generateCacheKey(final Object[] naturalIdValues, final EntityPersister persister,
+                                   final SessionImplementor session) {
+        return DefaultCacheKeysFactory.createNaturalIdKey(naturalIdValues, persister, session);
+    }
+
+    @Override
+    public Object get(final SessionImplementor session, final Object key, final long txTimestamp)
+            throws CacheException {
+        return delegate.get(key, txTimestamp);
+    }
+
+    @Override
+    public Object[] getNaturalIdValues(final Object cacheKey) {
+        return DefaultCacheKeysFactory.getNaturalIdValues(cacheKey);
+    }
+
+    @Override
+    public NaturalIdRegion getRegion() {
+        return delegate.getHazelcastRegion();
+    }
+
+    @Override
+    public boolean insert(final SessionImplementor session, final Object key, final Object value)
+            throws CacheException {
+        return delegate.insert(key, value, null);
+    }
+
+    @Override
+    public SoftLock lockItem(final SessionImplementor session, final Object key, final Object version)
+            throws CacheException {
+        return delegate.lockItem(key, version);
+    }
+
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        return delegate.lockRegion();
+    }
+
+    @Override
+    public boolean putFromLoad(final SessionImplementor session, final Object key, final Object value,
+                               final long txTimestamp, final Object version) throws CacheException {
+        return delegate.putFromLoad(key, value, txTimestamp, version);
+    }
+
+    @Override
+    public boolean putFromLoad(final SessionImplementor session, final Object key, final Object value,
+                               final long txTimestamp, final Object version, final boolean minimalPutOverride)
+            throws CacheException {
+        return delegate.putFromLoad(key, value, txTimestamp, version, minimalPutOverride);
+    }
+
+    @Override
+    public void remove(final SessionImplementor session, final Object key) throws CacheException {
+        delegate.remove(key);
+    }
+
+    @Override
+    public void removeAll() throws CacheException {
+        delegate.removeAll();
+    }
+
+    @Override
+    public void unlockItem(final SessionImplementor session, final Object key, final SoftLock lock)
+            throws CacheException {
+        delegate.unlockItem(key, lock);
+    }
+
+    @Override
+    public void unlockRegion(final SoftLock lock) throws CacheException {
+        delegate.unlockRegion(lock);
+    }
+
+    @Override
+    public boolean update(final SessionImplementor session, final Object key, final Object value)
+            throws CacheException {
+        return delegate.update(key, value, null, null);
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/package-info.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/region/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides region interfaces/classes for Hibernate.
+ */
+package com.hazelcast.hibernate.region;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+/**
+ * A container class which represents an entry in a region cache which can be marked for expiration
+ *
+ * @since 3.7
+ */
+public abstract class Expirable implements IdentifiedDataSerializable {
+
+    protected Object version;
+
+    protected Expirable() {
+    }
+
+    protected Expirable(final Object version) {
+        this.version = version;
+    }
+
+    /**
+     * Determine if the current entry can be overridden with a value corresponding to the given new version
+     * and the transaction timestamp.
+     *
+     * @param txTimestamp       the timestamp of the transaction
+     * @param newVersion        the new version for the replacement value
+     * @param versionComparator the comparator to use for the version
+     * @return {@code true} if the value can be replaced, {@code false} otherwise
+     */
+    public abstract boolean isReplaceableBy(final long txTimestamp, final Object newVersion,
+                                            final Comparator versionComparator);
+
+    /**
+     * @return the value contained, or {@code null} if none exists
+     */
+    public abstract Object getValue();
+
+    /**
+     * @param txTimestamp the timestamp of the transaction
+     * @return the value contained if it was created before the transaction timestamp or {@code null}
+     */
+    public abstract Object getValue(final long txTimestamp);
+
+    /**
+     * @return the version representing the value of {@code null} if the entry is not versioned
+     */
+    public Object getVersion() {
+        return version;
+    }
+
+    /**
+     * @return {@code true} if the {@link Expirable} matches using the specified lock, {@code false} otherwise
+     * @see ExpiryMarker#expire(long)
+     */
+    public abstract boolean matches(final ExpiryMarker lock);
+
+    /**
+     * Mark the entry for expiration with the given timeout and marker id.
+     * <p/>
+     * For every invocation a corresponding call to {@link ExpiryMarker#expire(long)} should be made, provided that
+     * the returned marker {@link #matches(ExpiryMarker)}
+     *
+     * @param timeout      the timestamp in which the lock times out
+     * @param nextMarkerId the next lock id to use if creating a new lock
+     * @return the newly created marker, or the current marker with a higher multiplicity
+     * @see ExpiryMarker#expire(long)
+     */
+    public abstract ExpiryMarker markForExpiration(final long timeout, final String nextMarkerId);
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(version);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        version = in.readObject();
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * An entry which is marked for expiration. This can occur when Hibernate is expecting to update an entry as a result
+ * of changes being made in an in-progress transaction
+ * <p/>
+ * Such an entry has the following properties
+ * <ul>
+ *     <li>It will always return a null value, resulting in a cache miss</li>
+ *     <li>It is only replaceable when it is completely expired</li>
+ *     <li>It can be marked by multiple transactions at the same time and will not expire until all transactions complete</li>
+ *     <li>It should not be expired unless {@link #matches(ExpiryMarker)} is true</li>
+ * </ul>
+ *
+ * @since 3.7
+ */
+public class ExpiryMarker extends Expirable implements Serializable {
+
+    private static final long NOT_COMPLETELY_EXPIRED = -1;
+    private boolean concurrent;
+    private long expiredTimestamp;
+    private String markerId;
+    private int multiplicity;
+    private long timeout;
+
+    public ExpiryMarker() {
+    }
+
+    public ExpiryMarker(final Object version, final long timeout, final String markerId) {
+        this(version, false, NOT_COMPLETELY_EXPIRED, markerId, 1, timeout);
+    }
+
+    private ExpiryMarker(final Object version, final boolean concurrent, final long expiredTimestamp,
+                         final String markerId, final int multiplicity, final long timeout) {
+        super(version);
+        this.concurrent = concurrent;
+        this.expiredTimestamp = expiredTimestamp;
+        this.markerId = markerId;
+        this.multiplicity = multiplicity;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public boolean isReplaceableBy(final long txTimestamp, final Object newVersion,
+                                   final Comparator versionComparator) {
+        // If the marker has timed out it should be fine to write to write to it
+        if (txTimestamp > timeout) {
+            return true;
+        }
+
+        // If the marker is still marked, it is definitely not replaceable
+        if (multiplicity > 0) {
+            return false;
+        }
+
+        if (version == null) {
+            // If the marker was expired in the past, its good to write to
+            return expiredTimestamp != NOT_COMPLETELY_EXPIRED && txTimestamp > expiredTimestamp;
+        }
+
+        //noinspection unchecked
+        return versionComparator.compare(version, newVersion) < 0;
+    }
+
+    @Override
+    public Object getValue() {
+        return null;
+    }
+
+    @Override
+    public Object getValue(final long txTimestamp) {
+        return null;
+    }
+
+    @Override
+    public boolean matches(final ExpiryMarker lock) {
+        return markerId.equals(lock.markerId);
+    }
+
+    /**
+     * @return {@code true} if the marker has ever been {@link #markForExpiration(long, String)}
+     *         concurrently, {@code false} otherwise
+     */
+    public boolean isConcurrent() {
+        return concurrent;
+    }
+
+    @Override
+    public ExpiryMarker markForExpiration(final long timeout, final String nextMarkerId) {
+        return new ExpiryMarker(version, true, NOT_COMPLETELY_EXPIRED, markerId, multiplicity + 1, timeout);
+    }
+
+    /**
+     * Expire the marker. The marker may have been marked multiple times so it may still not
+     * be {@link #isReplaceableBy(long, Object, Comparator) replaceable}.
+     *
+     * @param timestamp the timestamp to specify when it was completely expired
+     * @return a new {@link ExpiryMarker}
+     */
+    public ExpiryMarker expire(final long timestamp) {
+        int newMultiplicity = multiplicity - 1;
+        long newExpiredTimestamp = newMultiplicity == 0 ? timestamp : expiredTimestamp;
+
+        return new ExpiryMarker(version, concurrent, newExpiredTimestamp, markerId, newMultiplicity, timeout);
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+        out.writeBoolean(concurrent);
+        out.writeUTF(markerId);
+        out.writeInt(multiplicity);
+        out.writeLong(timeout);
+        out.writeLong(expiredTimestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        super.readData(in);
+        concurrent = in.readBoolean();
+        markerId = in.readUTF();
+        multiplicity = in.readInt();
+        timeout = in.readLong();
+        expiredTimestamp = in.readLong();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return HibernateDataSerializerHook.EXPIRY_MARKER;
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate51CacheEntrySerializer.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate51CacheEntrySerializer.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import org.hibernate.cache.spi.entry.CacheEntry;
+import org.hibernate.cache.spi.entry.StandardCacheEntryImpl;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * A {@code CacheEntry} serializer compatible with the SPI interface as updated for Hibernate 5.1. For reference
+ * entries the {@code CacheEntry} is serialized directly to avoid relying on too many Hibernate implementation
+ * details. Entity entries (the most common type) are serialized by accessing the fields using the interface's
+ * methods. Note that the {@code areLazyPropertiesUnfetched()} method was removed in 5.1.
+ *
+ * @since 3.7
+ */
+class Hibernate51CacheEntrySerializer
+        implements StreamSerializer<CacheEntry> {
+
+    private static final Constructor<StandardCacheEntryImpl> CACHE_ENTRY_CONSTRUCTOR;
+    private static final Class<?>[] CONSTRUCTOR_ARG_TYPES = {Serializable[].class, String.class, Object.class};
+
+    static {
+        try {
+            CACHE_ENTRY_CONSTRUCTOR = StandardCacheEntryImpl.class.getDeclaredConstructor(CONSTRUCTOR_ARG_TYPES);
+            CACHE_ENTRY_CONSTRUCTOR.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public int getTypeId() {
+        // SerializationConstants.HIBERNATE5_TYPE_HIBERNATE_CACHE_ENTRY
+        return -205;
+    }
+
+    @Override
+    public CacheEntry read(final ObjectDataInput in)
+            throws IOException {
+
+        try {
+            if (in.readBoolean()) {
+                return readReference(in);
+            }
+            return readDisassembled(in);
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    @Override
+    public void write(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        try {
+            out.writeBoolean(object.isReferenceEntry());
+            if (object.isReferenceEntry()) {
+                // Reference entries are not disassembled. Instead, to be serialized, they rely entirely on
+                // the entity itself being Serializable. This is not a common thing (Hibernate is currently
+                // very restrictive about what can be cached by reference), so it may not be worth dealing
+                // with at all. This is just a naive implementation relying on the entity's serialization.
+                writeReference(out, object);
+            } else {
+                writeDisassembled(out, object);
+            }
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    private static CacheEntry readDisassembled(final ObjectDataInput in)
+            throws IOException, IllegalAccessException, InvocationTargetException, InstantiationException {
+
+        int length = in.readInt();
+        Serializable[] disassembledState = new Serializable[length];
+        for (int i = 0; i < length; i++) {
+            disassembledState[i] = in.readObject();
+        }
+
+        String subclass = in.readUTF();
+        Object version = in.readObject();
+
+        return CACHE_ENTRY_CONSTRUCTOR.newInstance(disassembledState, subclass, version);
+    }
+
+    private static CacheEntry readReference(final ObjectDataInput in) throws IOException {
+        return ((CacheEntryWrapper) in.readObject()).entry;
+    }
+
+    private static IOException rethrow(final Exception e)
+            throws IOException {
+
+        if (e instanceof IOException) {
+            throw (IOException) e;
+        }
+        throw new IOException(e);
+    }
+
+    private static void writeDisassembled(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        Serializable[] disassembledState = object.getDisassembledState();
+        out.writeInt(disassembledState.length);
+        for (Serializable state : disassembledState) {
+            out.writeObject(state);
+        }
+
+        out.writeUTF(object.getSubclass());
+        out.writeObject(object.getVersion());
+    }
+
+    private static void writeReference(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        out.writeObject(new CacheEntryWrapper(object));
+    }
+
+    /**
+     * Wraps a CacheEntry so that serializing it will not recursively call back into this class.
+     * <p/>
+     * {@code CacheEntry} extends {@code Serializable}, so the entry could theoretically just be written with
+     * {@code ObjectDataOutput.writeObject(Object)}. However, doing so would cause the {@code SerializationService}
+     * to look up the serializer and route the entry right back here again, forming an infinite loop. This wrapper
+     * type, which has no explicit mapping, should fall back on the {@code ObjectSerializer} and be serialized by
+     * a standard {@code ObjectOutputStream}.
+     *
+     * @since 3.7
+     */
+    private static final class CacheEntryWrapper implements Serializable {
+
+        private final CacheEntry entry;
+
+        private CacheEntryWrapper(final CacheEntry entry) {
+            this.entry = entry;
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializer.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializer.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import org.hibernate.cache.spi.entry.CacheEntry;
+import org.hibernate.cache.spi.entry.StandardCacheEntryImpl;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * A {@code CacheEntry} serializer compatible with the SPI interface introduced in Hibernate 4.2 and still present
+ * in 5. For reference entries the {@code CacheEntry} is serialized directly to avoid relying on too many Hibernate
+ * implementation details. Entity entries (the most common type) are serialized by accessing the fields using the
+ * interface's methods.
+ *
+ * @since 3.7
+ */
+class Hibernate5CacheEntrySerializer
+        implements StreamSerializer<CacheEntry> {
+
+    private static final Constructor<StandardCacheEntryImpl> CACHE_ENTRY_CONSTRUCTOR;
+    private static final Class<?>[] CONSTRUCTOR_ARG_TYPES = {Serializable[].class, String.class, boolean.class, Object.class};
+
+    static {
+        try {
+            CACHE_ENTRY_CONSTRUCTOR = StandardCacheEntryImpl.class.getDeclaredConstructor(CONSTRUCTOR_ARG_TYPES);
+            CACHE_ENTRY_CONSTRUCTOR.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public int getTypeId() {
+        // SerializationConstants.HIBERNATE5_TYPE_HIBERNATE_CACHE_ENTRY
+        return -205;
+    }
+
+    @Override
+    public CacheEntry read(final ObjectDataInput in)
+            throws IOException {
+
+        try {
+            if (in.readBoolean()) {
+                return readReference(in);
+            }
+            return readDisassembled(in);
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    @Override
+    public void write(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        try {
+            out.writeBoolean(object.isReferenceEntry());
+            if (object.isReferenceEntry()) {
+                // Reference entries are not disassembled. Instead, to be serialized, they rely entirely on
+                // the entity itself being Serializable. This is not a common thing (Hibernate is currently
+                // very restrictive about what can be cached by reference), so it may not be worth dealing
+                // with at all. This is just a naive implementation relying on the entity's serialization.
+                writeReference(out, object);
+            } else {
+                writeDisassembled(out, object);
+            }
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    private static CacheEntry readDisassembled(final ObjectDataInput in)
+            throws IOException, IllegalAccessException, InvocationTargetException, InstantiationException {
+
+        int length = in.readInt();
+        Serializable[] disassembledState = new Serializable[length];
+        for (int i = 0; i < length; i++) {
+            disassembledState[i] = in.readObject();
+        }
+
+        String subclass = in.readUTF();
+        boolean lazyPropertiesAreUnfetched = in.readBoolean();
+        Object version = in.readObject();
+
+        return CACHE_ENTRY_CONSTRUCTOR.newInstance(disassembledState, subclass, lazyPropertiesAreUnfetched, version);
+    }
+
+    private static CacheEntry readReference(final ObjectDataInput in) throws IOException {
+        return ((CacheEntryWrapper) in.readObject()).entry;
+    }
+
+    private static IOException rethrow(final Exception e)
+            throws IOException {
+
+        if (e instanceof IOException) {
+            throw (IOException) e;
+        }
+        throw new IOException(e);
+    }
+
+    private static void writeDisassembled(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        Serializable[] disassembledState = object.getDisassembledState();
+        out.writeInt(disassembledState.length);
+        for (Serializable state : disassembledState) {
+            out.writeObject(state);
+        }
+
+        out.writeUTF(object.getSubclass());
+        out.writeBoolean(object.areLazyPropertiesUnfetched());
+        out.writeObject(object.getVersion());
+    }
+
+    private static void writeReference(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        out.writeObject(new CacheEntryWrapper(object));
+    }
+
+    /**
+     * Wraps a CacheEntry so that serializing it will not recursively call back into this class.
+     * <p/>
+     * {@code CacheEntry} extends {@code Serializable}, so the entry could theoretically just be written with
+     * {@code ObjectDataOutput.writeObject(Object)}. However, doing so would cause the {@code SerializationService}
+     * to look up the serializer and route the entry right back here again, forming an infinite loop. This wrapper
+     * type, which has no explicit mapping, should fall back on the {@code ObjectSerializer} and be serialized by
+     * a standard {@code ObjectOutputStream}.
+     *
+     * @since 3.7
+     */
+    private static final class CacheEntryWrapper implements Serializable {
+
+        private final CacheEntry entry;
+
+        private CacheEntryWrapper(final CacheEntry entry) {
+            this.entry = entry;
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.UnsafeHelper;
+import com.hazelcast.nio.serialization.Serializer;
+import com.hazelcast.nio.serialization.SerializerHook;
+
+/**
+ * This class is used to register a special serializer to not loose
+ * power over serialization in Hibernate 5.
+ *
+ * @since 3.7
+ */
+public class Hibernate5CacheEntrySerializerHook
+        implements SerializerHook {
+
+    private static final String SKIP_INIT_MSG = "Hibernate 5 not available, skipping serializer initialization";
+
+    private final Class<?> cacheEntryClass;
+
+    public Hibernate5CacheEntrySerializerHook() {
+        Class<?> cacheEntryClass = null;
+        if (UnsafeHelper.UNSAFE_AVAILABLE) {
+            try {
+                cacheEntryClass = Class.forName("org.hibernate.cache.spi.entry.StandardCacheEntryImpl");
+            } catch (Exception e) {
+                Logger.getLogger(Hibernate5CacheEntrySerializerHook.class).finest(SKIP_INIT_MSG);
+            }
+        }
+        this.cacheEntryClass = cacheEntryClass;
+    }
+
+    @Override
+    public Class getSerializationType() {
+        return cacheEntryClass;
+    }
+
+    @Override
+    public Serializer createSerializer() {
+        if (cacheEntryClass == null) {
+            return null;
+        }
+
+        try {
+            cacheEntryClass.getMethod("areLazyPropertiesUnfetched");
+
+            // If CacheEntry.areLazyPropertiesUnfetched() exists, we're on Hibernate 5
+            return new Hibernate5CacheEntrySerializer();
+        } catch (NoSuchMethodException e) {
+            // Otherwise, if there's no such method, we're on Hibernate 5.1+
+            return new Hibernate51CacheEntrySerializer();
+        }
+    }
+
+    @Override
+    public boolean isOverwritable() {
+        return true;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheKeySerializer.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheKeySerializer.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import static com.hazelcast.nio.UnsafeHelper.UNSAFE;
+
+/**
+ * The actual CacheKey serializer implementation
+ *
+ * @since 3.7
+ */
+class Hibernate5CacheKeySerializer
+        implements StreamSerializer<Object> {
+
+    private static final Class<?> CACHE_KEY_CLASS;
+    private static final long KEY_OFFSET;
+    private static final long TYPE_OFFSET;
+    private static final long ENTITY_OR_ROLE_NAME_OFFSET;
+    private static final long TENANT_ID_OFFSET;
+    private static final long HASH_CODE_OFFSET;
+
+    static {
+        try {
+            CACHE_KEY_CLASS = Class.forName("org.hibernate.cache.internal.OldCacheKeyImplementation");
+
+            Field key = CACHE_KEY_CLASS.getDeclaredField("id");
+            KEY_OFFSET = UNSAFE.objectFieldOffset(key);
+
+            Field type = CACHE_KEY_CLASS.getDeclaredField("type");
+            TYPE_OFFSET = UNSAFE.objectFieldOffset(type);
+
+            Field entityOrRoleName = CACHE_KEY_CLASS.getDeclaredField("entityOrRoleName");
+            ENTITY_OR_ROLE_NAME_OFFSET = UNSAFE.objectFieldOffset(entityOrRoleName);
+
+            Field tenantId = CACHE_KEY_CLASS.getDeclaredField("tenantId");
+            TENANT_ID_OFFSET = UNSAFE.objectFieldOffset(tenantId);
+
+            Field hashCode = CACHE_KEY_CLASS.getDeclaredField("hashCode");
+            HASH_CODE_OFFSET = UNSAFE.objectFieldOffset(hashCode);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void write(final ObjectDataOutput out, final Object object)
+            throws IOException {
+
+        try {
+            Object key = UNSAFE.getObject(object, KEY_OFFSET);
+            Object type = UNSAFE.getObject(object, TYPE_OFFSET);
+            String entityOrRoleName = (String) UNSAFE.getObject(object, ENTITY_OR_ROLE_NAME_OFFSET);
+            String tenantId = (String) UNSAFE.getObject(object, TENANT_ID_OFFSET);
+            int hashCode = UNSAFE.getInt(object, HASH_CODE_OFFSET);
+
+            out.writeObject(key);
+            out.writeObject(type);
+            out.writeUTF(entityOrRoleName);
+            out.writeUTF(tenantId);
+            out.writeInt(hashCode);
+
+        } catch (Exception e) {
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            }
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Object read(final ObjectDataInput in)
+            throws IOException {
+
+        try {
+            Object key = in.readObject();
+            Object type = in.readObject();
+            String entityOrRoleName = in.readUTF();
+            String tenantId = in.readUTF();
+            int hashCode = in.readInt();
+
+            Object cacheKey = UNSAFE.allocateInstance(CACHE_KEY_CLASS);
+            UNSAFE.putObjectVolatile(cacheKey, KEY_OFFSET, key);
+            UNSAFE.putObjectVolatile(cacheKey, TYPE_OFFSET, type);
+            UNSAFE.putObjectVolatile(cacheKey, ENTITY_OR_ROLE_NAME_OFFSET, entityOrRoleName);
+            UNSAFE.putObjectVolatile(cacheKey, TENANT_ID_OFFSET, tenantId);
+            UNSAFE.putIntVolatile(cacheKey, HASH_CODE_OFFSET, hashCode);
+            return cacheKey;
+
+        } catch (Exception e) {
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            }
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public int getTypeId() {
+        // SerializationConstants.HIBERNATE5_TYPE_HIBERNATE_CACHE_KEY
+        return -204;
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheKeySerializerHook.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheKeySerializerHook.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.UnsafeHelper;
+import com.hazelcast.nio.serialization.Serializer;
+import com.hazelcast.nio.serialization.SerializerHook;
+
+/**
+ * This class is used to register a special serializer to not loose
+ * power over serialization in Hibernate 5
+ *
+ * @since 3.7
+ */
+public class Hibernate5CacheKeySerializerHook
+        implements SerializerHook {
+
+    private static final String SKIP_INIT_MSG = "Hibernate 5 not available, skipping serializer initialization";
+
+    private final Class<?> cacheKeyClass;
+
+    public Hibernate5CacheKeySerializerHook() {
+        Class<?> cacheKeyClass = null;
+        if (UnsafeHelper.UNSAFE_AVAILABLE) {
+            try {
+                cacheKeyClass = Class.forName("org.hibernate.cache.internal.OldCacheKeyImplementation");
+            } catch (Exception e) {
+                Logger.getLogger(Hibernate5CacheKeySerializerHook.class).finest(SKIP_INIT_MSG);
+            }
+        }
+        this.cacheKeyClass = cacheKeyClass;
+    }
+
+    @Override
+    public Class getSerializationType() {
+        return cacheKeyClass;
+    }
+
+    @Override
+    public Serializer createSerializer() {
+        if (cacheKeyClass != null) {
+            return new Hibernate5CacheKeySerializer();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isOverwritable() {
+        return true;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5NaturalIdKeySerializer.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5NaturalIdKeySerializer.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+
+import static com.hazelcast.nio.UnsafeHelper.UNSAFE;
+
+/**
+ * Handles serialization for Hibernate's {@code OldNaturalIdCacheKey}, used for the keys in natural ID regions.
+ *
+ * @since 3.7
+ */
+class Hibernate5NaturalIdKeySerializer
+        implements StreamSerializer<Object> {
+
+    private static final Class<?> CACHE_KEY_CLASS;
+    private static final long ENTITY_NAME_OFFSET;
+    private static final long HASH_CODE_OFFSET;
+    private static final long NATURAL_ID_VALUES_OFFSET;
+    private static final long TENANT_ID_OFFSET;
+
+    static {
+        try {
+            CACHE_KEY_CLASS = Class.forName("org.hibernate.cache.internal.OldNaturalIdCacheKey");
+
+            Field key = CACHE_KEY_CLASS.getDeclaredField("naturalIdValues");
+            NATURAL_ID_VALUES_OFFSET = UNSAFE.objectFieldOffset(key);
+
+            Field type = CACHE_KEY_CLASS.getDeclaredField("entityName");
+            ENTITY_NAME_OFFSET = UNSAFE.objectFieldOffset(type);
+
+            Field tenantId = CACHE_KEY_CLASS.getDeclaredField("tenantId");
+            TENANT_ID_OFFSET = UNSAFE.objectFieldOffset(tenantId);
+
+            Field hashCode = CACHE_KEY_CLASS.getDeclaredField("hashCode");
+            HASH_CODE_OFFSET = UNSAFE.objectFieldOffset(hashCode);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void write(final ObjectDataOutput out, final Object object)
+            throws IOException {
+
+        try {
+            Serializable[] naturalIdValues = (Serializable[]) UNSAFE.getObject(object, NATURAL_ID_VALUES_OFFSET);
+            String entityName = (String) UNSAFE.getObject(object, ENTITY_NAME_OFFSET);
+            String tenantId = (String) UNSAFE.getObject(object, TENANT_ID_OFFSET);
+            int hashCode = UNSAFE.getInt(object, HASH_CODE_OFFSET);
+
+            out.writeObject(naturalIdValues);
+            out.writeUTF(entityName);
+            out.writeUTF(tenantId);
+            out.writeInt(hashCode);
+
+        } catch (Exception e) {
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            }
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public Object read(final ObjectDataInput in)
+            throws IOException {
+
+        try {
+            Serializable[] key = in.readObject();
+            String entityName = in.readUTF();
+            String tenantId = in.readUTF();
+            int hashCode = in.readInt();
+
+            Object cacheKey = UNSAFE.allocateInstance(CACHE_KEY_CLASS);
+            UNSAFE.putObjectVolatile(cacheKey, NATURAL_ID_VALUES_OFFSET, key);
+            UNSAFE.putObjectVolatile(cacheKey, ENTITY_NAME_OFFSET, entityName);
+            UNSAFE.putObjectVolatile(cacheKey, TENANT_ID_OFFSET, tenantId);
+            UNSAFE.putIntVolatile(cacheKey, HASH_CODE_OFFSET, hashCode);
+            return cacheKey;
+
+        } catch (Exception e) {
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            }
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public int getTypeId() {
+        // SerializationConstants.HIBERNATE5_TYPE_HIBERNATE_NATURAL_ID_KEY
+        return -206;
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5NaturalIdKeySerializerHook.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5NaturalIdKeySerializerHook.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.UnsafeHelper;
+import com.hazelcast.nio.serialization.Serializer;
+import com.hazelcast.nio.serialization.SerializerHook;
+
+/**
+ * This class is used to register a special serializer to not loose
+ * power over serialization in Hibernate 5
+ *
+ * @since 3.7
+ */
+public class Hibernate5NaturalIdKeySerializerHook
+        implements SerializerHook {
+
+    private static final String SKIP_INIT_MSG = "Hibernate 5 not available, skipping serializer initialization";
+
+    private final Class<?> cacheKeyClass;
+
+    public Hibernate5NaturalIdKeySerializerHook() {
+        Class<?> cacheKeyClass = null;
+        if (UnsafeHelper.UNSAFE_AVAILABLE) {
+            try {
+                cacheKeyClass = Class.forName("org.hibernate.cache.internal.OldNaturalIdCacheKey");
+            } catch (Exception e) {
+                Logger.getLogger(Hibernate5NaturalIdKeySerializerHook.class).finest(SKIP_INIT_MSG);
+            }
+        }
+        this.cacheKeyClass = cacheKeyClass;
+    }
+
+    @Override
+    public Class getSerializationType() {
+        return cacheKeyClass;
+    }
+
+    @Override
+    public Serializer createSerializer() {
+        if (cacheKeyClass != null) {
+            return new Hibernate5NaturalIdKeySerializer();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isOverwritable() {
+        return true;
+    }
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/HibernateDataSerializerHook.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/HibernateDataSerializerHook.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.hibernate.distributed.LockEntryProcessor;
+import com.hazelcast.hibernate.distributed.UnlockEntryProcessor;
+import com.hazelcast.hibernate.distributed.UpdateEntryProcessor;
+import com.hazelcast.hibernate.local.Invalidation;
+import com.hazelcast.hibernate.local.Timestamp;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+
+/**
+ * An implementation of {@link DataSerializerHook} which constructs any of the
+ * {@link com.hazelcast.nio.serialization.DataSerializable} objects for the
+ * hibernate module
+ *
+ * @since 3.7
+ */
+public class HibernateDataSerializerHook implements DataSerializerHook {
+
+    /**
+     * The factory id for this class
+     */
+    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.HIBERNATE_DS_FACTORY, F_ID_OFFSET_HIBERNATE);
+    /**
+     * @see Value
+     */
+    public static final int VALUE = 0;
+    /**
+     * @see ExpiryMarker
+     */
+    public static final int EXPIRY_MARKER = 1;
+    /**
+     * @see LockEntryProcessor
+     */
+    public static final int LOCK = 2;
+    /**
+     * @see UnlockEntryProcessor
+     */
+    public static final int UNLOCK = 3;
+    /**
+     * @see UpdateEntryProcessor
+     */
+    public static final int UPDATE = 4;
+    /**
+     * @see Invalidation
+     */
+    public static final int INVALIDATION = 5;
+    /**
+     * @see Timestamp
+     */
+    public static final int TIMESTAMP = 6;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        return new Factory();
+    }
+
+    private static class Factory implements DataSerializableFactory {
+        @Override
+        public IdentifiedDataSerializable create(final int typeId) {
+            IdentifiedDataSerializable result;
+            switch (typeId) {
+                case VALUE:
+                    result = new Value();
+                    break;
+                case EXPIRY_MARKER:
+                    result = new ExpiryMarker();
+                    break;
+                case LOCK:
+                    result = new LockEntryProcessor();
+                    break;
+                case UNLOCK:
+                    result = new UnlockEntryProcessor();
+                    break;
+                case UPDATE:
+                    result = new UpdateEntryProcessor();
+                    break;
+                case INVALIDATION:
+                    result = new Invalidation();
+                    break;
+                case TIMESTAMP:
+                    result = new Timestamp();
+                    break;
+                default:
+                    result = null;
+            }
+            return result;
+        }
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.cache.spi.access.SoftLock;
+
+/**
+ * A wrapper class for ExpiryMarker for returning copy of marker object with
+ * {@link org.hibernate.cache.spi.access.SoftLock} marker interface.
+ *
+ * @since 3.7
+ */
+public class MarkerWrapper implements SoftLock {
+
+    private final ExpiryMarker marker;
+
+    public MarkerWrapper(final ExpiryMarker marker) {
+        this.marker = marker;
+    }
+
+    public ExpiryMarker getMarker() {
+        return marker;
+    }
+}
+

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Value.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Value.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import java.io.IOException;
+import java.util.Comparator;
+
+/**
+ * A value within a region cache
+ *
+ * @since 3.7
+ */
+public class Value extends Expirable {
+
+    private long timestamp;
+    private Object value;
+
+    public Value() {
+    }
+
+    public Value(final Object version, final long timestamp, final Object value) {
+        super(version);
+        this.timestamp = timestamp;
+        this.value = value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean isReplaceableBy(final long txTimestamp, final Object newVersion,
+                                   final Comparator versionComparator) {
+        return version == null
+                ? timestamp <= txTimestamp
+                : versionComparator.compare(version, newVersion) < 0;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public Object getValue() {
+        return value;
+    }
+
+    @Override
+    public Object getValue(final long txTimestamp) {
+        return timestamp <= txTimestamp ? value : null;
+    }
+
+    @Override
+    public boolean matches(final ExpiryMarker lock) {
+        return false;
+    }
+
+    @Override
+    public ExpiryMarker markForExpiration(final long timeout, final String nextMarkerId) {
+        return new ExpiryMarker(version, timeout, nextMarkerId);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        super.readData(in);
+        timestamp = in.readLong();
+        value = in.readObject();
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+        out.writeLong(timestamp);
+        out.writeObject(value);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return HibernateDataSerializerHook.VALUE;
+    }
+
+}

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/package-info.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class contains the Hibernate 5 serializer hooks so what we don't
+ * lose handling on serialization while working on Hibernate.
+ */
+package com.hazelcast.hibernate.serialization;

--- a/hazelcast-hibernate5/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast-hibernate5/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -1,0 +1,1 @@
+com.hazelcast.hibernate.serialization.HibernateDataSerializerHook

--- a/hazelcast-hibernate5/src/main/resources/META-INF/services/com.hazelcast.SerializerHook
+++ b/hazelcast-hibernate5/src/main/resources/META-INF/services/com.hazelcast.SerializerHook
@@ -1,0 +1,3 @@
+com.hazelcast.hibernate.serialization.Hibernate5CacheKeySerializerHook
+com.hazelcast.hibernate.serialization.Hibernate5CacheEntrySerializerHook
+com.hazelcast.hibernate.serialization.Hibernate5NaturalIdKeySerializerHook

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Read and write access (non-strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Nonstrict means that data integrity is not preserved as strictly as in READ_WRITE access
+ * Cache invalidations are asychrnonous
+ * Read through cache
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheHitMissNonStrictTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.NONSTRICT_READ_WRITE.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+
+        //entity 2 and its properties are invalidated
+
+        //miss updated entity, hit 4 properties(they are still the same)
+        getPropertiesOfEntity(sf, 2);
+
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(2, dummyEntityCacheStats.getHitCount());
+        assertEquals(11, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test
+    public void testUpdateEventuallyInvalidatesObject() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+        assertSizeEventually(9, dummyEntityCacheStats.getEntries());
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Read-only access cache concurrency strategy of Hibernate.
+ * Data may be added and removed, but not mutated.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheHitMissReadOnlyTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_ONLY.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+
+        assertEquals(4, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(1, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        insertDummyEntities(10);
+        executeUpdateQuery(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyUpdate() throws Exception{
+        insertDummyEntities(1, 0);
+        updateDummyEntityName(sf, 0, "updated");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAfterUpdateShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateQueryCausesInvalidationOfEntireCollectionRegion() {
+        insertDummyEntities(1, 10);
+
+        //attempt to evict properties reference in DummyEntity because of custom SQL query on Collection region
+        executeUpdateQuery(sf, "update DummyProperty ent set ent.key='manually-updated'");
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Read and write access (strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Strict means data integrity is preserved strictly (by locks)
+ * Write through cache
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheHitMissReadWriteTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_WRITE.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+
+        //hit 1 entity, hit 4 properties
+        getPropertiesOfEntity(sf, 2);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(3, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+
+    }
+
+    @Test
+    public void testUpdateShouldNotInvalidateEntryInCache() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities, 10 entities are cached
+        getDummyEntities(sf, 10);
+
+        //updates cache entity
+        updateDummyEntityName(sf, 2, "updated");
+
+        assertEquals(10, dummyEntityCacheStats.getElementCountInMemory());
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.ClasspathXmlConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.service.spi.ServiceException;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class CustomPropertiesTest extends HibernateTestSupport {
+
+    @Test
+    public void testNativeClient() throws Exception {
+
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+        Config config = new ClasspathXmlConfig("hazelcast-custom.xml");
+        HazelcastInstance main = factory.newHazelcastInstance(config);
+        Properties props = getDefaultProperties();
+        props.remove(CacheEnvironment.CONFIG_FILE_PATH_LEGACY);
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_GROUP, "dev-custom");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_PASSWORD, "dev-pass");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_ADDRESS, "localhost");
+        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH,"hazelcast-client-custom.xml");
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        loader.configure(props);
+        loader.setInstanceFactory(factory);
+        SessionFactory sf = createSessionFactory(props, loader);
+        HazelcastInstance hz = HazelcastAccessor.getHazelcastInstance(sf);
+        assertTrue(hz instanceof HazelcastClientProxy);
+        assertEquals(1, main.getCluster().getMembers().size());
+        HazelcastClientProxy client = (HazelcastClientProxy) hz;
+        ClientConfig clientConfig = client.getClientConfig();
+        assertEquals("dev-custom", clientConfig.getGroupConfig().getName());
+        assertEquals("dev-pass", clientConfig.getGroupConfig().getPassword());
+        assertTrue(clientConfig.getNetworkConfig().isSmartRouting());
+        assertTrue(clientConfig.getNetworkConfig().isRedoOperation());
+        factory.newHazelcastInstance(config);
+        assertEquals(2, hz.getCluster().getMembers().size());
+        main.shutdown();
+        Thread.sleep(1000 * 1); // let client to reconnect
+        assertEquals(1, hz.getCluster().getMembers().size());
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        session.save(new DummyEntity(1L, "dummy", 0, new Date()));
+        tx.commit();
+        session.close();
+        sf.close();
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testNamedInstance() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+        Config config = new Config();
+        config.setInstanceName("hibernate");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.put(CacheEnvironment.HAZELCAST_INSTANCE_NAME, "hibernate");
+        props.put(CacheEnvironment.SHUTDOWN_ON_STOP, "false");
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+
+        SessionFactory sf = configuration.buildSessionFactory();
+        assertTrue(hz.equals(HazelcastAccessor.getHazelcastInstance(sf)));
+        sf.close();
+        assertTrue(hz.getLifecycleService().isRunning());
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testHazelcastAccessorReturnsNullIfSecondLevelCacheIsNotHazelcast() {
+        Properties props = new Properties();
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+        SessionFactory sf = configuration.buildSessionFactory();
+
+        assertNull(HazelcastAccessor.getHazelcastInstance(sf));
+
+        sf.close();
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testWrongHazelcastConfigurationFilePathShouldThrow() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        //we give a non-exist config file address, should fail fast
+        props.setProperty("hibernate.cache.hazelcast.configuration_file_path", "non-exist.xml");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+        SessionFactory sf = configuration.buildSessionFactory();
+        sf.close();
+    }
+
+    private Properties getDefaultProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH_LEGACY, "hazelcast-custom.xml");
+        return props;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+public abstract class HibernateSlowTestSupport extends HibernateTestSupport {
+
+    protected SessionFactory sf;
+    protected SessionFactory sf2;
+
+    @Before
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        sf2 = createSessionFactory(getCacheProperties(), null);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        if (sf2 != null) {
+            sf2.close();
+            sf2 = null;
+        }
+        Hazelcast.shutdownAll();
+    }
+
+    protected abstract Properties getCacheProperties();
+
+    protected void insertDummyEntities(int count) {
+        insertDummyEntities(count, 0);
+    }
+
+    protected void insertDummyEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = new DummyEntity((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyProperty p = new DummyProperty("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected List<DummyEntity> executeQuery(SessionFactory factory) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName());
+            query.setCacheable(false);
+            return query.list();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected DummyEntity executeQuery(SessionFactory factory, long id) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName() + " where id = " + id);
+            query.setCacheable(true);
+            return (DummyEntity) query.list().get(0);
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class HibernateStatisticsTestSupport extends HibernateTestSupport {
+
+    protected SessionFactory sf;
+    protected SessionFactory sf2;
+
+    protected final String CACHE_ENTITY = DummyEntity.class.getName();
+    protected final String CACHE_PROPERTY = DummyProperty.class.getName();
+
+    private static  TestHazelcastFactory factory;
+
+    @Before
+    public void postConstruct() {
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        factory = new TestHazelcastFactory();
+        loader.setInstanceFactory(factory);
+        sf = createSessionFactory(getCacheProperties(),  loader);
+        sf2 = createSessionFactory(getCacheProperties(), loader);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        if (sf2 != null) {
+            sf2.close();
+            sf2 = null;
+        }
+        Hazelcast.shutdownAll();
+        factory.shutdownAll();
+    }
+
+    protected abstract Properties getCacheProperties();
+
+    protected void insertDummyEntities(int count) {
+        insertDummyEntities(count, 0);
+    }
+
+    protected void insertDummyEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = new DummyEntity((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyProperty p = new DummyProperty("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void insertAnnotatedEntities(int count) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        for(int i=0; i< count; i++) {
+            AnnotatedEntity annotatedEntity = new AnnotatedEntity("dummy:"+i);
+            session.save(annotatedEntity);
+        }
+        tx.commit();
+        session.close();
+    }
+
+    protected List<DummyEntity> executeQuery(SessionFactory factory) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName());
+            query.setCacheable(true);
+            return query.list();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected ArrayList<DummyEntity> getDummyEntities(SessionFactory sf, long untilId) {
+        Session session = sf.openSession();
+        ArrayList<DummyEntity> entities = new ArrayList<DummyEntity>();
+        for (long i=0; i<untilId; i++) {
+            DummyEntity entity = session.get(DummyEntity.class, i);
+            if (entity != null) {
+                session.evict(entity);
+                entities.add(entity);
+            }
+        }
+        session.close();
+        return entities;
+    }
+
+    protected Set<DummyProperty> getPropertiesOfEntity(SessionFactory sf, long entityId) {
+        Session session = sf.openSession();
+        DummyEntity entity = session.get(DummyEntity.class, entityId);
+        if(entity != null) {
+            return entity.getProperties();
+        } else {
+            return null;
+        }
+    }
+
+    protected void updateDummyEntityName(SessionFactory sf, long id, String newName) {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            DummyEntity entityToUpdate = session.get(DummyEntity.class, id);
+            entityToUpdate.setName(newName);
+            session.update(entityToUpdate);
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void deleteDummyEntity(SessionFactory sf, long id)
+            throws Exception {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            DummyEntity entityToDelete = session.get(DummyEntity.class, id);
+            session.delete(entityToDelete);
+            txn.commit();
+        } catch (Exception e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void executeUpdateQuery(SessionFactory sf, String queryString)
+            throws RuntimeException {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery(queryString);
+            query.setCacheable(true);
+            query.executeUpdate();
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    @Test
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        insertDummyEntities(10);
+
+        executeUpdateQuery(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
+
+        sf.getStatistics().clear();
+
+        getDummyEntities(sf, 10);
+
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+        assertEquals(0, dummyEntityCacheStats.getHitCount());
+    }
+
+    @Test
+    public void testUpdateQueryCausesInvalidationOfEntireCollectionRegion() {
+        insertDummyEntities(1, 10);
+
+        //properties reference in DummyEntity is evicted because of custom SQL query on Collection region
+        executeUpdateQuery(sf, "update DummyProperty ent set ent.key='manually-updated'");
+        sf.getStatistics().clear();
+
+        //property reference missed in cache.
+        getPropertiesOfEntity(sf, 0);
+
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY + ".properties");
+        assertEquals(0, dummyPropertyCacheStats.getHitCount());
+        assertEquals(1, dummyPropertyCacheStats.getMissCount());
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.hibernate.SessionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Configuration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.*;
+import java.util.Properties;
+
+public abstract class HibernateTestSupport extends HazelcastTestSupport {
+
+    private final ILogger logger = Logger.getLogger(getClass());
+
+    @BeforeClass
+    @AfterClass
+    public static void tearUpAndDown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @After
+    public final void cleanup() {
+        Hazelcast.shutdownAll();
+    }
+
+    protected String getCacheStrategy() {
+        return  AccessType.READ_WRITE.getExternalName();
+    }
+
+    protected void sleep(int seconds) {
+        try {
+            Thread.sleep(1000 * seconds);
+        } catch (InterruptedException e) {
+            logger.warning("", e);
+        }
+    }
+
+    protected void addHbmMappings(final Configuration conf) {
+        conf.addFile(createHbmXml("DummyEntity"));
+        conf.addFile(createHbmXml("DummyProperty"));
+    }
+
+    protected void addMappings(final Configuration conf) {
+        conf.addAnnotatedClass(AnnotatedEntity.class);
+        addHbmMappings(conf);
+    }
+
+    protected SessionFactory createSessionFactory(final Properties props,
+                                                  final IHazelcastInstanceLoader customInstanceLoader) {
+        props.put(CacheEnvironment.EXPLICIT_VERSION_CHECK, "true");
+        if (customInstanceLoader != null) {
+            props.put("com.hazelcast.hibernate.instance.loader", customInstanceLoader);
+            customInstanceLoader.configure(props);
+        } else {
+            props.remove("com.hazelcast.hibernate.instance.loader");
+        }
+
+        final Configuration conf = new Configuration();
+        conf.configure(HibernateTestSupport.class.getClassLoader().getResource("test-hibernate.cfg.xml"));
+        addMappings(conf);
+        conf.addProperties(props);
+
+        final SessionFactory sf = conf.buildSessionFactory();
+        sf.getStatistics().setStatisticsEnabled(true);
+
+        return sf;
+    }
+
+    protected HazelcastInstance getHazelcastInstance(final SessionFactory sf) {
+        return HazelcastAccessor.getHazelcastInstance(sf);
+    }
+
+    /**
+     * Starting in Hibernate 5, it is no longer possible to set an explicit cache mode for an entity on the
+     * {@code Configuration} object. The cache mode can <i>only</i> be defined in the {@code hbm.xml} file,
+     * for entities configured via XML, or directly on the annotated class.
+     * <p>
+     * To work around that restriction, the {@code hbm.xml} files are treated as templates, with placeholders
+     * for their cache modes. This method opens that template resource, replaces the cache mode and writes it
+     * to a temporary file (which is marked for delete-on-exit to do housekeeping). This way, the test being
+     * run can still control the caching mode.
+     *
+     * @param baseName the base name for the {@code hbm.xml} file to create
+     */
+    private File createHbmXml(final String baseName) {
+        InputStream inputStream = null;
+        BufferedReader reader = null;
+        BufferedWriter writer = null;
+
+        try {
+            inputStream = getClass().getResourceAsStream("/hbm/" + baseName + ".xml");
+            reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+
+            final File hbmXmlFile = File.createTempFile(baseName, "hbm.xml");
+            hbmXmlFile.deleteOnExit();
+
+            writer = new BufferedWriter(new FileWriter(hbmXmlFile));
+            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                writer.write(String.format(line, getCacheStrategy()));
+                writer.newLine();
+            }
+            writer.flush();
+
+            return hbmXmlFile;
+        } catch (final IOException e) {
+            throw new IllegalStateException("Could not prepare " + baseName + ".hbm.xml", e);
+        } finally {
+            IOUtil.closeResource(writer);
+            IOUtil.closeResource(reader);
+            IOUtil.closeResource(inputStream);
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.Statistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testEntity() {
+        final HazelcastInstance hz = getHazelcastInstance(sf);
+        assertNotNull(hz);
+        final int count = 100;
+        final int childCount = 3;
+        insertDummyEntities(count, childCount);
+        List<DummyEntity> list = new ArrayList<DummyEntity>(count);
+        Session session = sf.openSession();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = session.get(DummyEntity.class, (long) i);
+                session.evict(e);
+                list.add(e);
+            }
+        } finally {
+            session.close();
+        }
+        session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                dummy.setDate(new Date());
+                session.update(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        assertEquals((childCount + 1) * count, stats.getEntityInsertCount());
+        // twice put of entity and properties (on load and update) and once put of collection
+        assertEquals((childCount + 1) * count * 2 + count, stats.getSecondLevelCachePutCount());
+        assertEquals(childCount * count, stats.getEntityLoadCount());
+        assertEquals(count, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(count, stats.getSecondLevelCacheMissCount());
+        stats.logSummary();
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class LocalRegionFactorySlowTest extends HibernateSlowTestSupport {
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf2.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/NativeClientTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/NativeClientTest.java
@@ -1,0 +1,76 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class NativeClientTest
+        extends HibernateSlowTestSupport {
+
+    protected SessionFactory clientSf;
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Before
+    @Override
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        clientSf = createClientSessionFactory(getCacheProperties());
+    }
+
+    @Test
+    public void testInsertLoad() {
+        Session session = clientSf.openSession();
+        Transaction tx = session.beginTransaction();
+        DummyEntity e = new DummyEntity((long) 1, "dummy:1", 123456d, new Date());
+        session.save(e);
+        tx.commit();
+        session.close();
+
+        session = clientSf.openSession();
+        DummyEntity retrieved = session.get(DummyEntity.class, (long)1);
+        assertEquals("dummy:1", retrieved.getName());
+    }
+
+    @After
+    public void tearDown() {
+        if(clientSf !=null) {
+            clientSf.close();
+        }
+    }
+
+    protected SessionFactory createClientSessionFactory(Properties props) {
+        Configuration conf = new Configuration();
+        conf.configure(HibernateTestSupport.class.getClassLoader().getResource("test-hibernate-client.cfg.xml"));
+        addHbmMappings(conf);
+        conf.addProperties(props);
+
+        final SessionFactory sf = conf.buildSessionFactory();
+        sf.getStatistics().setStatisticsEnabled(true);
+
+        return sf;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/NaturalIdTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/NaturalIdTest.java
@@ -1,0 +1,137 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.test.HazelcastTestRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.criterion.Restrictions;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastTestRunner.class)
+@Category(SlowTest.class)
+public class NaturalIdTest extends HibernateStatisticsTestSupport {
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[]{AccessType.READ_WRITE},
+                new Object[]{AccessType.READ_ONLY},
+                new Object[]{AccessType.NONSTRICT_READ_WRITE}
+        );
+    }
+
+    @Parameterized.Parameter(0)
+    public AccessType defaultAccessType;
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.put("TestAccessType", defaultAccessType);
+        props.setProperty(Environment.CACHE_REGION_FACTORY, InternalMockRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testNaturalIdCacheEvictsEntityOnUpdate() {
+        Assume.assumeTrue(defaultAccessType == AccessType.READ_WRITE);
+
+        insertAnnotatedEntities(1);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        //1 cache hit since dummy:0 just inserted and still in the cache
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheHitCount());
+
+        //dummy:0 should be evicted and this leads to a cache miss
+        session = sf.openSession();
+        Criteria criteria = session.createCriteria(AnnotatedEntity.class).add(Restrictions.naturalId().set("title","dummy:0"))
+                                   .setCacheable(true);
+        criteria.uniqueResult();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheMissCount());
+    }
+
+    @Test
+    public void testNaturalIdCacheStillHitsAfterIrrelevantNaturalIdUpdate() {
+        Assume.assumeTrue(defaultAccessType == AccessType.READ_WRITE);
+
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        //1 cache hit since dummy:1 just inserted and still in the cache
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheHitCount());
+
+        //only dummy:1 should be evicted from cache on contrary to behavior of hibernate query cache without natural ids
+        session = sf.openSession();
+        Criteria criteria = session.createCriteria(AnnotatedEntity.class).add(Restrictions.naturalId().set("title","dummy:0"))
+                                   .setCacheable(true);
+        criteria.uniqueResult();
+
+        //cache hit dummy:0 + previous hit
+        assertEquals(2, sf.getStatistics().getNaturalIdCacheHitCount());
+    }
+
+    @Test
+    public void testFindByNaturalId() {
+        insertAnnotatedEntities(1);
+        Session session = sf.openSession();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        assertEquals("dummy:0", toBeUpdated.getTitle());
+        session.close();
+    }
+
+    @Test
+    public void testEvictionNaturalId() {
+        insertAnnotatedEntities(1);
+        sf.getCache().evictNaturalIdRegion(AnnotatedEntity.class);
+        assertFalse(sf.getCache().containsEntity(AnnotatedEntity.class, 0L));
+    }
+
+    public static class InternalMockRegionFactory
+            extends HazelcastCacheRegionFactory {
+
+        private AccessType defaultAccessType;
+
+        public InternalMockRegionFactory() {
+            super();
+        }
+
+        public InternalMockRegionFactory(final Properties properties) {
+            super(properties);
+            defaultAccessType = (AccessType) properties.get("TestAccessType");
+        }
+
+        @Override
+        public AccessType getDefaultAccessType() {
+            return defaultAccessType;
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class RegionFactoryDefaultSlowTest
+        extends HibernateSlowTestSupport {
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testQueryCacheCleanup() {
+
+        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
+        final float baseEvictionRate = 0.2f;
+        final int numberOfEntities = 100;
+        final int defaultCleanupPeriod = 60;
+        final int maxSize = mapConfig.getMaxSizeConfig().getSize();
+        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
+        insertDummyEntities(numberOfEntities);
+        for (int i = 0; i < numberOfEntities; i++) {
+            executeQuery(sf, i);
+        }
+
+        HazelcastQueryResultsRegion queryRegion = ((HazelcastQueryResultsRegion) (((SessionFactoryImpl) sf).getQueryCache()).getRegion());
+        assertEquals(numberOfEntities, queryRegion.getCache().size());
+        sleep(defaultCleanupPeriod);
+
+        assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
+    }
+
+    @Test
+    public void testUpdateEntity() {
+        final long dummyId = 0;
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        session.save(new DummyEntity(dummyId, null, 0, null));
+        tx.commit();
+
+        tx = session.beginTransaction();
+        DummyEntity ent = (DummyEntity) session.get(DummyEntity.class, dummyId);
+        ent.setName("updatedName");
+        session.update(ent);
+        tx.commit();
+        session.close();
+
+        session = sf2.openSession();
+        DummyEntity entity = (DummyEntity) session.get(DummyEntity.class, dummyId);
+        assertEquals("updatedName", entity.getName());
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.Repeat;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.Statistics;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testEntity() {
+        final HazelcastInstance hz = getHazelcastInstance(sf);
+        assertNotNull(hz);
+        final int count = 100;
+        final int childCount = 3;
+        insertDummyEntities(count, childCount);
+        List<DummyEntity> list = new ArrayList<DummyEntity>(count);
+        Session session = sf.openSession();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = session.get(DummyEntity.class, (long) i);
+                session.evict(e);
+                list.add(e);
+            }
+        } finally {
+            session.close();
+        }
+        session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                dummy.setDate(new Date());
+                session.update(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        Map<?, ?> cache = hz.getMap(DummyEntity.class.getName());
+        Map<?, ?> propCache = hz.getMap(DummyProperty.class.getName());
+        Map<?, ?> propCollCache = hz.getMap(DummyEntity.class.getName() + ".properties");
+        assertEquals((childCount + 1) * count, stats.getEntityInsertCount());
+        // twice put of entity and properties (on load and update) and once put of collection
+        // TODO: fix next assertion ->
+        //        assertEquals((childCount + 1) * count * 2, stats.getSecondLevelCachePutCount());
+        assertEquals(childCount * count, stats.getEntityLoadCount());
+        assertEquals(count, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(count, stats.getSecondLevelCacheMissCount());
+        assertEquals(count, cache.size());
+        assertEquals(count * childCount, propCache.size());
+        assertEquals(count, propCollCache.size());
+        sf.getCache().evictEntityRegion(DummyEntity.class);
+        sf.getCache().evictEntityRegion(DummyProperty.class);
+        assertEquals(0, cache.size());
+        assertEquals(0, propCache.size());
+        stats.logSummary();
+    }
+
+    public void testQuery() throws Exception {
+        final int entityCount = 10;
+        final int queryCount = 3;
+        insertDummyEntities(entityCount);
+        // After inserting the entities, we need a slight delay. Otherwise, when the queries run, it's possible
+        // that the UpdateTimestampsCache entry for DummyEntity still matches the current timestamp. When that
+        // happens, this test fails because the StandardQueryCache considers the cached data out-of-date, which
+        // results in an extra miss and put in the statistics. By delaying slightly here, we can be certain our
+        // queries will have newer timestamps then tha cache does
+        sleep(1);
+
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                session.delete(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        assertEquals(1, stats.getQueryCachePutCount());
+        assertEquals(1, stats.getQueryCacheMissCount());
+        assertEquals(queryCount - 1, stats.getQueryCacheHitCount());
+        assertEquals(1, stats.getQueryExecutionCount());
+        assertEquals(entityCount, stats.getEntityInsertCount());
+        //      FIXME
+        //      HazelcastRegionFactory puts into L2 cache 2 times; 1 on insert, 1 on query execution
+        //      assertEquals(entityCount, stats.getSecondLevelCachePutCount());
+        assertEquals(entityCount, stats.getEntityLoadCount());
+        assertEquals(entityCount, stats.getEntityDeleteCount());
+        assertEquals(entityCount * (queryCount - 1) * 2, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(entityCount, stats.getSecondLevelCacheMissCount());
+        stats.logSummary();
+    }
+
+    @Test
+    public void testSpecificQueryRegionEviction() {
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+
+        //miss 1 query list entities
+        Session session = sf.openSession();
+        Transaction txn = session.beginTransaction();
+        Query query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true).setCacheRegion("newregionname");
+        query.list();
+        txn.commit();
+        session.close();
+        //query is cached
+
+        //query is invalidated
+        sf.getCache().evictQueryRegion("newregionname");
+
+        //miss 1 query
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true);
+        query.list();
+        txn.commit();
+        session.close();
+
+        assertEquals(0, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
+    }
+
+    @Test
+    public void testInsertGetUpdateGet() {
+        Session session = sf.openSession();
+        DummyEntity e = new DummyEntity(1L, "test", 0d, null);
+        Transaction tx = session.beginTransaction();
+        try {
+            session.save(e);
+            tx.commit();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            tx.rollback();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+
+        session = sf.openSession();
+        try {
+            e = session.get(DummyEntity.class, 1L);
+            assertEquals("test", e.getName());
+            assertNull(e.getDate());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+
+        session = sf.openSession();
+        tx = session.beginTransaction();
+        try {
+            e = session.get(DummyEntity.class, 1L);
+            assertEquals("test", e.getName());
+            assertNull(e.getDate());
+            e.setName("dummy");
+            e.setDate(new Date());
+            session.update(e);
+            tx.commit();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            tx.rollback();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+
+        session = sf.openSession();
+        try {
+            e = session.get(DummyEntity.class, 1L);
+            assertEquals("dummy", e.getName());
+            Assert.assertNotNull(e.getDate());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+    }
+
+    @Test
+    public void testEvictionEntity() {
+        insertDummyEntities(1, 1);
+        sf.getCache().evictEntity("com.hazelcast.hibernate.entity.DummyEntity", 0L);
+        assertFalse(sf.getCache().containsEntity("com.hazelcast.hibernate.entity.DummyEntity", 0L));
+    }
+
+    @Test
+    public void testEvictionCollection() {
+        insertDummyEntities(1, 1);
+        sf.getCache().evictCollection("com.hazelcast.hibernate.entity.DummyEntity.properties", 0L);
+        assertFalse(sf.getCache().containsCollection("com.hazelcast.hibernate.entity.DummyEntity.properties", 0L));
+    }
+
+    @Test
+    public void testInsertEvictUpdate() {
+        insertDummyEntities(1);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        DummyEntity ent = session.get(DummyEntity.class, 0L);
+        sf.getCache().evictEntity("com.hazelcast.hibernate.entity.DummyEntity", 0L);
+        ent.setName("updatedName");
+        session.update(ent);
+        tx.commit();
+        session.close();
+        ArrayList<DummyEntity> list = getDummyEntities(sf, 1);
+        assertEquals("updatedName", list.get(0).getName());
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class RegionFactoryQueryTest extends HibernateSlowTestSupport{
+
+    @Before
+    @Override
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        sf2 = createSessionFactory(getCacheProperties(), null);
+    }
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/VersionAwareMapMergePolicyTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/VersionAwareMapMergePolicyTest.java
@@ -1,0 +1,97 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.merge.MapMergePolicy;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.entry.CacheEntry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class VersionAwareMapMergePolicyTest {
+
+
+    private static final MockVersion versionOld = new MockVersion(0);
+    private static final MockVersion versionNew = new MockVersion(1);
+
+    protected MapMergePolicy policy;
+
+    @Before
+    public void given() {
+        policy = new VersionAwareMapMergePolicy();
+    }
+
+    @Test
+    public void merge_mergingUptodate() {
+        CacheEntry existing = cacheEntryWithVersion(versionOld);
+        CacheEntry merging = cacheEntryWithVersion(versionNew);
+
+        EntryView entryExisting = entryWithGivenValue(existing);
+        EntryView entryMerging = entryWithGivenValue(merging);
+
+        assertEquals(merging, policy.merge("map", entryMerging, entryExisting));
+    }
+
+    @Test
+    public void merge_mergingStale() {
+        CacheEntry existing = cacheEntryWithVersion(versionNew);
+        CacheEntry merging = cacheEntryWithVersion(versionOld);
+
+        EntryView entryExisting = entryWithGivenValue(existing);
+        EntryView entryMerging = entryWithGivenValue(merging);
+
+        assertEquals(existing, policy.merge("map", entryMerging, entryExisting));
+    }
+
+    @Test
+    public void merge_mergingNull() {
+        CacheEntry existing = null;
+        CacheEntry merging = cacheEntryWithVersion(versionNew);
+
+        EntryView entryExisting = entryWithGivenValue(existing);
+        EntryView entryMerging = entryWithGivenValue(merging);
+
+        assertEquals(merging, policy.merge("map", entryMerging, entryExisting));
+    }
+
+
+    private CacheEntry cacheEntryWithVersion(MockVersion mockVersion) {
+        CacheEntry cacheEntry = mock(CacheEntry.class);
+        when(cacheEntry.getVersion()).thenReturn(mockVersion);
+        return cacheEntry;
+    }
+
+    private EntryView entryWithGivenValue(Object value) {
+        EntryView entryView = mock(EntryView.class);
+        try {
+            when(entryView.getValue()).thenReturn(value);
+            return entryView;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    protected static class MockVersion implements Comparable<MockVersion> {
+
+        private int version;
+
+        public MockVersion(int version) {
+            this.version = version;
+        }
+
+        @Override
+        public int compareTo(MockVersion o) {
+            return version - o.version;
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegateTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegateTest.java
@@ -1,0 +1,67 @@
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.HibernateTestSupport;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.log4j.Level;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ReadWriteAccessDelegateTest extends HibernateTestSupport {
+
+    private RegionCache cache;
+    private ReadWriteAccessDelegate<HazelcastRegion> delegate;
+
+    @BeforeClass
+    public static void setLogging() {
+        setLoggingLog4j();
+        setLogLevel(Level.TRACE);
+    }
+
+    @AfterClass
+    public static void resetLogging() {
+        resetLogLevel();
+    }
+
+    @Before
+    public void setUp() {
+        ILogger log = Logger.getLogger(ReadWriteAccessDelegateTest.class);
+
+        cache = mock(RegionCache.class);
+
+        HazelcastRegion region = mock(HazelcastRegion.class);
+        when(region.getLogger()).thenReturn(log);
+        when(region.getCache()).thenReturn(cache);
+
+        delegate = new ReadWriteAccessDelegate<HazelcastRegion>(region, null);
+    }
+
+    @Test
+    public void testAfterInsert() {
+        when(cache.insert(any(), any(), any())).thenThrow(new HazelcastException("expected exception"));
+        assertFalse(delegate.afterInsert(null, null, null));
+    }
+
+    @Test
+    public void testAfterUpdate() {
+        when(cache.update(any(), any(), any(), any(SoftLock.class))).thenThrow(new HazelcastException("expected exception"));
+        assertFalse(delegate.afterUpdate(null, null, null, null, null));
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LockEntryProcessorTest {
+
+    @Test
+    public void testProcessWithNullEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(null);
+        LockEntryProcessor processor = new LockEntryProcessor("next-marker-id", 100L, null);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertTrue(marker.matches(new ExpiryMarker(null, 0L, "next-marker-id")));
+    }
+
+    @Test
+    public void testProcessWithValueEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new Value(null, 500L, "blah"));
+        LockEntryProcessor processor = new LockEntryProcessor("next-marker-id", 100L, null);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertTrue(marker.matches(new ExpiryMarker(null, 0L, "next-marker-id")));
+    }
+
+    @Test
+    public void testProcessWithMarkerEntry() throws Exception {
+        ExpiryMarker original = new ExpiryMarker(null, 0L, "the-marker-id");
+        Map.Entry<Object, Expirable> entry = mockEntry(original);
+        LockEntryProcessor processor = new LockEntryProcessor("next-marker-id", 100L, null);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertFalse(marker.matches(new ExpiryMarker(null, 0L, "next-marker-id")));
+        assertTrue(marker.matches(original));
+        assertTrue(marker.isConcurrent());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map.Entry<Object, Expirable> mockEntry(Expirable value) {
+        Map.Entry entry = mock(Map.Entry.class);
+        when(entry.getValue()).thenReturn(value);
+        return entry;
+    }
+
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class UnlockEntryProcessorTest {
+
+    @Test
+    public void testProcessWithNullEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(null);
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "other-marker-id"), "next-marker-id", 100L);
+        processor.process(entry);
+        verify(entry, never()).setValue(any(Expirable.class));
+    }
+
+    @Test
+    public void testProcessWithDifferentMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "the-marker-id"));
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "other-marker-id"), "next-marker-id", 100L);
+        processor.process(entry);
+        verify(entry, never()).setValue(any(Expirable.class));
+    }
+
+    @Test
+    public void testProcessWithValue() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new Value(null, 100L, "some-value"));
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "other-marker-id"), "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertFalse("market must be expirable after timestamp", marker.isReplaceableBy(150L, null, null));
+        assertTrue("market must be expirable after timestamp", marker.isReplaceableBy(151L, null, null));
+    }
+
+    @Test
+    public void testProcessMatchingLock() throws Exception {
+        ExpiryMarker original = new ExpiryMarker(null, 100L, "the-marker-id").markForExpiration(100L, "some-marker-id");
+        Map.Entry<Object, Expirable> entry = mockEntry(original);
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertNotSame(original, result);
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertTrue(marker.matches(original));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map.Entry<Object, Expirable> mockEntry(Expirable value) {
+        Map.Entry entry = mock(Map.Entry.class);
+        when(entry.getValue()).thenReturn(value);
+        return entry;
+    }
+
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
@@ -1,0 +1,79 @@
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class UpdateEntryProcessorTest {
+
+    @Test
+    public void testProcessWithNullEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(null);
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertTrue(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(Value.class));
+        assertEquals("new-value", result.getValue());
+    }
+
+    @Test
+    public void testProcessWithMatchingMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "the-marker-id"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertTrue(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(Value.class));
+        assertEquals("new-value", result.getValue());
+    }
+
+    @Test
+    public void testProcessWithMatchingConcurrentMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "the-marker-id").markForExpiration(100L, "ignored"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertFalse(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+    }
+
+    @Test
+    public void testProcessWithDifferentMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "other-marker-id"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        assertFalse(processor.process(entry));
+        verify(entry, never()).setValue(any(Expirable.class));
+    }
+
+    @Test
+    public void testProcessWithValue() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new Value(null, 100L, "some-value"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertFalse(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        assertTrue("Marker should be expired", result.isReplaceableBy(151L, null, null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map.Entry<Object, Expirable> mockEntry(Expirable value) {
+        Map.Entry entry = mock(Map.Entry.class);
+        when(entry.getValue()).thenReturn(value);
+        return entry;
+    }
+
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/AnnotatedEntity.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/AnnotatedEntity.java
@@ -1,0 +1,46 @@
+package com.hazelcast.hibernate.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@NaturalIdCache
+@Entity
+@Table( name = "ANNOTATED_ENTITIES" )
+public class AnnotatedEntity {
+    private Long id;
+
+    private String title;
+
+    public AnnotatedEntity() {
+    }
+
+    public AnnotatedEntity(String title) {
+        this.title = title;
+    }
+
+    @NaturalId(mutable = true)
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @Id
+    @GeneratedValue(generator="increment")
+    @GenericGenerator(name="increment", strategy = "increment")
+    public Long getId() {
+        return id;
+    }
+
+    private void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+import java.util.Date;
+import java.util.Set;
+
+public class DummyEntity {
+
+    private long id;
+
+    private int version;
+
+    private String name;
+
+    private double value;
+
+    private Date date;
+
+    private Set<DummyProperty> properties;
+
+    public DummyEntity() {
+        super();
+    }
+
+    public DummyEntity(long id, String name, double value, Date date) {
+        super();
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.date = date;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public void setProperties(Set<DummyProperty> properties) {
+        this.properties = properties;
+    }
+
+    public Set<DummyProperty> getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/DummyProperty.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/DummyProperty.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+public class DummyProperty {
+
+    private long id;
+
+    private int version;
+
+    private String key;
+
+    private DummyEntity entity;
+
+    public DummyProperty() {
+    }
+
+    public DummyProperty(String key) {
+        super();
+        this.key = key;
+    }
+
+    public DummyProperty(String key, DummyEntity entity) {
+        super();
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public DummyProperty(long id, String key, DummyEntity entity) {
+        super();
+        this.id = id;
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public DummyEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(DummyEntity entity) {
+        this.entity = entity;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -1,0 +1,178 @@
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigLoader;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.DuplicateInstanceNameException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
+
+    private static final ILogger LOGGER = Logger.getLogger(HazelcastMockInstanceLoader.class);
+    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+
+    private final Properties props = new Properties();
+    private String instanceName;
+    private HazelcastInstance instance;
+    private Config config;
+    private HazelcastInstance client;
+    private TestHazelcastFactory factory;
+    public void configure(Properties props) {
+        this.props.putAll(props);
+    }
+
+    public HazelcastInstance loadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client != null && client.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastClient is already active! Shutting it down...");
+                unloadInstance();
+            }
+            String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
+            String group = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+            String pass = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
+            String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+
+            ClientConfig clientConfig = buildClientConfig(configResourcePath);
+            if (group != null) {
+                clientConfig.getGroupConfig().setName(group);
+            }
+            if (pass != null) {
+                clientConfig.getGroupConfig().setPassword(pass);
+            }
+            if (address != null) {
+                clientConfig.getNetworkConfig().addAddress(address);
+            }
+            clientConfig.getNetworkConfig().setSmartRouting(true);
+            clientConfig.getNetworkConfig().setRedoOperation(true);
+            client = factory.newHazelcastClient(clientConfig);
+            return client;
+        } else {
+            if (instance != null && instance.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastInstance is already loaded and running! "
+                        + "Returning current instance...");
+                return instance;
+            }
+            String configResourcePath = null;
+            instanceName = CacheEnvironment.getInstanceName(props);
+            configResourcePath = CacheEnvironment.getConfigFilePath(props);
+            if (!isEmpty(configResourcePath)) {
+                try {
+                    config = ConfigLoader.load(configResourcePath);
+                } catch (IOException e) {
+                    LOGGER.warning("IOException: " + e.getMessage());
+                }
+                if (config == null) {
+                    throw new CacheException("Could not find configuration file: "
+                            + configResourcePath);
+                }
+            }
+            if (instanceName != null) {
+                instance = getHazelcastInstanceByName(instanceName);
+                if (instance == null) {
+                    try {
+                        createOrGetInstance();
+                    } catch (DuplicateInstanceNameException ignored) {
+                        instance = getHazelcastInstanceByName(instanceName);
+                    }
+                }
+            } else {
+                createOrGetInstance();
+            }
+            return instance;
+        }
+    }
+
+    private void createOrGetInstance() throws DuplicateInstanceNameException {
+        if (config == null) {
+            config = new XmlConfigBuilder().build();
+        }
+        config.setInstanceName(instanceName);
+        instance = factory.newHazelcastInstance(config);
+    }
+
+    public void unloadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client == null) {
+                return;
+            }
+            try {
+                client.getLifecycleService().shutdown();
+                client = null;
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        } else {
+            if (instance == null) {
+                return;
+            }
+            final boolean shutDown = CacheEnvironment.shutdownOnStop(props, (instanceName == null));
+            if (!shutDown) {
+                LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
+                        + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
+                        + GroupProperty.SHUTDOWNHOOK_ENABLED + " property!)");
+                return;
+            }
+            try {
+                instance.getLifecycleService().shutdown();
+                instance = null;
+                factory.shutdownAll();
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        }
+    }
+
+    public TestHazelcastFactory getInstanceFactory() throws CacheException {
+        return factory;
+    }
+
+    public void setInstanceFactory(TestHazelcastFactory factory) {
+        this.factory = factory;
+    }
+
+    private static boolean isEmpty(String s) {
+        return s == null || s.trim().length() == 0;
+    }
+
+    private HazelcastInstance getHazelcastInstanceByName(String instanceName) {
+        HazelcastInstance foundInstance = null;
+        for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
+            if(instanceName.equals(instance.getName())) {
+                foundInstance = instance;
+            }
+        }
+        return foundInstance;
+    }
+
+    private ClientConfig buildClientConfig(String configResourcePath) {
+        ClientConfig clientConfig = null;
+        if (configResourcePath != null) {
+            try {
+                clientConfig = new XmlClientConfigBuilder(configResourcePath).build();
+            } catch (IOException e) {
+                LOGGER.warning("Could not load client configuration: " + configResourcePath, e);
+            }
+        }
+        if (clientConfig == null) {
+            clientConfig = new ClientConfig();
+            final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+            networkConfig.setSmartRouting(true);
+            networkConfig.setRedoOperation(true);
+            networkConfig.setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+        }
+        return clientConfig;
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,0 +1,99 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Comparator;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("unchecked")
+public class LocalRegionCacheTest {
+
+    private static final String CACHE_NAME = "cache";
+
+    @Test
+    public void testConstructorIgnoresUnsupportedOperationExceptionsFromConfig() {
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        doThrow(UnsupportedOperationException.class).when(instance).getConfig();
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+    }
+
+    @Test
+    public void testConstructorIgnoresVersionComparatorForUnversionedData() {
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        doThrow(AssertionError.class).when(description).getVersionComparator(); // Will fail the test if called
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).isVersioned(); // Verify that the versioned flag was checked
+        verifyNoMoreInteractions(description);
+    }
+
+    @Test
+    public void testConstructorSetsVersionComparatorForVersionedData() {
+        Comparator<?> comparator = mock(Comparator.class);
+
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        when(description.getVersionComparator()).thenReturn(comparator);
+        when(description.isVersioned()).thenReturn(true);
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).getVersionComparator();
+        verify(description).isVersioned();
+    }
+
+    @Test
+    public void testFourArgConstructorDoesNotRegisterTopicListenerIfNotRequested() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance, never()).getTopic(anyString());
+    }
+
+    // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance
+    // is provided. This ensures the old behavior has not been regressed by adding the new four argument constructor
+    @Test
+    public void testThreeArgConstructorRegistersTopicListener() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        ITopic<Object> topic = mock(ITopic.class);
+        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn("ignored");
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        new LocalRegionCache(CACHE_NAME, instance, null);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance).getTopic(eq(CACHE_NAME));
+        verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    public static void runCleanup(LocalRegionCache cache) {
+        cache.cleanup();
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
@@ -1,0 +1,129 @@
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.hibernate.local.LocalRegionCacheTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class HazelcastQueryResultsRegionTest {
+
+    private static final String REGION_NAME = "query.test";
+
+    private int maxSize = 50;
+    private int timeout = 60;
+
+    private MapConfig mapConfig;
+    private Config config;
+
+    private HazelcastInstance instance;
+    private HazelcastQueryResultsRegion region;
+
+    @Before
+    public void setUp() throws Exception {
+        mapConfig = mock(MapConfig.class);
+        when(mapConfig.getMaxSizeConfig()).thenReturn(new MaxSizeConfig(maxSize, MaxSizeConfig.MaxSizePolicy.PER_NODE));
+        when(mapConfig.getTimeToLiveSeconds()).thenReturn(timeout);
+
+        config = mock(Config.class);
+        when(config.findMapConfig(eq(REGION_NAME))).thenReturn(mapConfig);
+
+        Cluster cluster = mock(Cluster.class);
+        when(cluster.getClusterTime()).thenAnswer(new Answer<Long>() {
+            @Override
+            public Long answer(InvocationOnMock invocation) throws Throwable {
+                return System.currentTimeMillis();
+            }
+        });
+
+        instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getCluster()).thenReturn(cluster);
+
+        region = new HazelcastQueryResultsRegion(instance, REGION_NAME, new Properties());
+    }
+
+    /**
+     * Verifies that the region retrieved the MapConfig and set its timeout from the TTL.
+     * Also verifies that the nested LocalRegionCache retrieved the configuration,
+     * but did not register a listener on any ITopic.
+     */
+    @Test
+    public void testCacheHonorsConfiguration() {
+        assertEquals(TimeUnit.SECONDS.toMillis(timeout), region.getTimeout());
+        verify(instance, atLeastOnce()).getConfig();
+        // ensure a topic is not requested
+        verify(instance, never()).getTopic(anyString());
+        verify(config, atLeastOnce()).findMapConfig(eq(REGION_NAME));
+        // should have been retrieved by the region itself
+        verify(mapConfig, times(2)).getTimeToLiveSeconds();
+
+        // load the cache with more entries than the configured max size
+        LocalRegionCache regionCache = region.getCache();
+        assertNotNull(regionCache);
+
+        int overSized = maxSize * 2;
+        for (int i = 0; i < overSized; ++i) {
+            regionCache.put(i, i, System.currentTimeMillis(), i);
+        }
+        assertEquals(overSized, regionCache.size());
+
+        // run cleanup to apply the configured limits (the TTL is not tested here for simplicity and speed of this test)
+        LocalRegionCacheTest.runCleanup(regionCache);
+        // the default size is 100,000, so if the configuration is ignored no elements will be removed.
+        // But if the configuration is applied as expected
+        assertTrue(regionCache.size() <= 50);
+        verify(mapConfig).getMaxSizeConfig();
+        verify(mapConfig, times(3)).getTimeToLiveSeconds(); // Should have been retrieved a second time by the cache
+    }
+
+    @Test
+    public void testEvict() {
+        region.evict("evictionKey");
+    }
+
+    @Test
+    public void testEvictAll() {
+        region.evictAll();
+    }
+
+    @Test
+    public void testGet() {
+        assertNull(region.get(null, "getKey"));
+    }
+
+    @Test
+    public void testPut() {
+        region.put(null, "putKey", "putValue");
+        assertEquals("putValue", region.get(null, "putKey"));
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegionTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegionTest.java
@@ -1,0 +1,141 @@
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class HazelcastTimestampsRegionTest {
+
+    private static final String REGION_NAME = "query.test";
+
+    private int timeout = 60;
+
+    private MapConfig mapConfig;
+    private Config config;
+
+    private HazelcastInstance instance;
+    private RegionCache cache;
+    private HazelcastTimestampsRegion<RegionCache> region;
+
+    @Before
+    public void setUp() throws Exception {
+        mapConfig = mock(MapConfig.class);
+        when(mapConfig.getMaxSizeConfig()).thenReturn(new MaxSizeConfig(50, MaxSizeConfig.MaxSizePolicy.PER_NODE));
+        when(mapConfig.getTimeToLiveSeconds()).thenReturn(timeout);
+
+        config = mock(Config.class);
+        when(config.findMapConfig(eq(REGION_NAME))).thenReturn(mapConfig);
+
+        Cluster cluster = mock(Cluster.class);
+        when(cluster.getClusterTime()).thenAnswer(new Answer<Long>() {
+            @Override
+            public Long answer(InvocationOnMock invocation) throws Throwable {
+                return System.currentTimeMillis();
+            }
+        });
+
+        instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getCluster()).thenReturn(cluster);
+
+        cache = mock(RegionCache.class);
+
+        region = new HazelcastTimestampsRegion<RegionCache>(instance, REGION_NAME, new Properties(), cache);
+    }
+
+    /**
+     * Verifies that the region retrieved the MapConfig and set its timeout from the TTL.
+     * Also verifies that the nested LocalRegionCache retrieved the configuration,
+     * but did not register a listener on any ITopic.
+     */
+    @Test
+    public void testCacheHonorsConfiguration() {
+        assertEquals(cache, region.getCache());
+
+        assertEquals(TimeUnit.SECONDS.toMillis(timeout), region.getTimeout());
+        verify(instance, atLeastOnce()).getConfig();
+        // ensure a topic is not requested
+        verify(instance, never()).getTopic(anyString());
+        verify(config, atLeastOnce()).findMapConfig(eq(REGION_NAME));
+        // should have been retrieved by the region itself
+        verify(mapConfig, times(2)).getTimeToLiveSeconds();
+    }
+
+    @Test
+    public void testEvict() {
+        region.evict("evictionKey");
+    }
+
+    @Test
+    public void testEvict_withException() {
+        doThrow(new OperationTimeoutException("expected exception")).when(cache).remove(eq("evictionKey"));
+        region.evict("evictionKey");
+    }
+
+    @Test
+    public void testEvictAll() {
+        region.evictAll();
+    }
+
+    @Test
+    public void testEvictAll_withException() {
+        doThrow(new OperationTimeoutException("expected exception")).when(cache).clear();
+        region.evictAll();
+    }
+
+    @Test
+    public void testGet() {
+        assertNull(region.get(null, "getKey"));
+    }
+
+    @Test
+    public void testGet_withException() {
+        doThrow(new OperationTimeoutException("expected exception")).when(cache).get(eq("getKey"), anyLong());
+        assertNull(region.get(null, "getKey"));
+    }
+
+    @Test
+    public void testPut() {
+        region.put(null, "putKey", "putValue");
+        verify(cache).put(eq("putKey"), eq("putValue"), anyLong(), any());
+    }
+
+    @Test
+    public void testPut_withException() {
+        doThrow(new OperationTimeoutException("expected exception"))
+                .when(cache).put(eq("putKey"), eq("putValue"), anyLong(), any());
+        region.put(null, "putKey", "putValue");
+        verify(cache).put(eq("putKey"), eq("putValue"), anyLong(), any());
+    }
+
+    @Test
+    public void testCache() {
+        assertEquals(cache, region.getCache());
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
@@ -1,0 +1,79 @@
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.internal.util.compare.ComparableComparator;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExpiryMarkerTest {
+
+    @Test
+    public void testIsReplaceableByTimestampBeforeTimeout() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 100L, "the-marker-id");
+        assertFalse("marker is not replaceable when it hasn't timed out", marker.isReplaceableBy(99L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampEqualTimeout() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 100L, "the-marker-id");
+        assertFalse("marker is not replaceable when it hasn't timed out", marker.isReplaceableBy(100L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampAfterTimeout() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 100L, "the-marker-id");
+        assertTrue("marker is replaceable when it has timed out", marker.isReplaceableBy(101L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampBeforeExpiredTimestamp() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is not replaceable when it when timestamp before expiry",
+                marker.isReplaceableBy(99L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampEqualExpiredTimestamp() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is not replaceable when it when timestamp equal to expiry",
+                marker.isReplaceableBy(100L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampAfterExpiredTimestamp() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 150L, "the-marker-id").expire(100L);
+        assertTrue("marker is replaceable when it when timestamp after expiry",
+                marker.isReplaceableBy(101L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionBefore() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is replaceable when it when version before",
+                marker.isReplaceableBy(101L, 9, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionEqual() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is replaceable when it when version equal",
+                marker.isReplaceableBy(101L, 10, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionAfter() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id").expire(100L);
+        assertTrue("marker is replaceable when it when version after",
+                marker.isReplaceableBy(99L, 11, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testMatchesOnlyUsesMarkerId() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id");
+        assertTrue(marker.matches(marker));
+        assertTrue(marker.matches(marker.expire(100)));
+        assertTrue(marker.matches(marker.markForExpiration(100L, "some-other-marker-id")));
+        assertTrue(marker.matches(new ExpiryMarker(9, 100L, "the-marker-id")));
+        assertFalse(marker.matches(new ExpiryMarker(10, 150L, "some-other-marker-id")));
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.entry.StandardCacheEntryImpl;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HibernateSerializationHookAvailableTest {
+
+    private static final Field ORIGINAL;
+    private static final Field TYPE_MAP;
+
+    static {
+        try {
+            ORIGINAL = HazelcastInstanceProxy.class.getDeclaredField("original");
+            ORIGINAL.setAccessible(true);
+
+            TYPE_MAP = AbstractSerializationService.class.getDeclaredField("typeMap");
+            TYPE_MAP.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @After
+    public void teardown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testAutoregistrationOnHibernate5Available()
+            throws Exception {
+
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance();
+        HazelcastInstanceImpl impl = (HazelcastInstanceImpl) ORIGINAL.get(hz);
+        SerializationService ss = impl.getSerializationService();
+        @SuppressWarnings("unchecked")
+        ConcurrentMap<Class, ?> typeMap = (ConcurrentMap) TYPE_MAP.get(ss);
+
+        boolean cacheKeySerializerFound = false;
+        boolean cacheEntrySerializerFound = false;
+        boolean naturalIdKeySerializerFound = false;
+        for (Class clazz : typeMap.keySet()) {
+            // The Old* implementations are matched by class name here just to avoid the Reflection hassle
+            // of retrieving their classes, since they're package-private
+            if ("org.hibernate.cache.internal.OldCacheKeyImplementation".equals(clazz.getName())) {
+                cacheKeySerializerFound = true;
+            } else if ("org.hibernate.cache.internal.OldNaturalIdCacheKey".equals(clazz.getName())) {
+                naturalIdKeySerializerFound = true;
+            } else if (StandardCacheEntryImpl.class.equals(clazz)) {
+                cacheEntrySerializerFound = true;
+            }
+        }
+
+        assertTrue("CacheKey serializer not found", cacheKeySerializerFound);
+        assertTrue("CacheEntry serializer not found", cacheEntrySerializerFound);
+        assertTrue("NaturalIdCacheKey serializer not found", naturalIdKeySerializerFound);
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.FilteringClassLoader;
+import org.hibernate.cache.spi.entry.StandardCacheEntryImpl;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HibernateSerializationHookNonAvailableTest {
+
+    private static final Field ORIGINAL;
+    private static final Field TYPE_MAP;
+    private static final Method GET_SERIALIZATION_SERVICE;
+
+    private static final ClassLoader FILTERING_CLASS_LOADER;
+
+    static {
+        try {
+            List<String> excludes = Collections.singletonList("org.hibernate");
+            FILTERING_CLASS_LOADER = new FilteringClassLoader(excludes, "com.hazelcast");
+
+            String hazelcastInstanceImplClassName = "com.hazelcast.instance.HazelcastInstanceImpl";
+            Class<?> hazelcastInstanceImplClass = FILTERING_CLASS_LOADER.loadClass(hazelcastInstanceImplClassName);
+            GET_SERIALIZATION_SERVICE = hazelcastInstanceImplClass.getMethod("getSerializationService");
+
+            String hazelcastInstanceProxyClassName = "com.hazelcast.instance.HazelcastInstanceProxy";
+            Class<?> hazelcastInstanceProxyClass = FILTERING_CLASS_LOADER.loadClass(hazelcastInstanceProxyClassName);
+            ORIGINAL = hazelcastInstanceProxyClass.getDeclaredField("original");
+            ORIGINAL.setAccessible(true);
+
+            String serializationServiceImplClassName = "com.hazelcast.internal.serialization.impl.AbstractSerializationService";
+            Class<?> serializationServiceImplClass = FILTERING_CLASS_LOADER.loadClass(serializationServiceImplClassName);
+            TYPE_MAP = serializationServiceImplClass.getDeclaredField("typeMap");
+            TYPE_MAP.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testAutoregistrationOnHibernate5NonAvailable()
+            throws Exception {
+
+        Thread thread = Thread.currentThread();
+        ClassLoader tccl = thread.getContextClassLoader();
+
+        try {
+            thread.setContextClassLoader(FILTERING_CLASS_LOADER);
+
+            Class<?> configClazz = FILTERING_CLASS_LOADER.loadClass("com.hazelcast.config.Config");
+            Object config = configClazz.newInstance();
+            Method setClassLoader = configClazz.getDeclaredMethod("setClassLoader", ClassLoader.class);
+
+            setClassLoader.invoke(config, FILTERING_CLASS_LOADER);
+
+            Class<?> hazelcastClazz = FILTERING_CLASS_LOADER.loadClass("com.hazelcast.core.Hazelcast");
+            Method newHazelcastInstance = hazelcastClazz.getDeclaredMethod("newHazelcastInstance", configClazz);
+
+            Object hz = newHazelcastInstance.invoke(hazelcastClazz, config);
+            Object impl = ORIGINAL.get(hz);
+            Object serializationService = GET_SERIALIZATION_SERVICE.invoke(impl);
+            ConcurrentMap<Class, ?> typeMap = (ConcurrentMap<Class, ?>) TYPE_MAP.get(serializationService);
+            boolean cacheKeySerializerFound = false;
+            boolean cacheEntrySerializerFound = false;
+            boolean naturalIdKeySerializerFound = false;
+            for (Class clazz : typeMap.keySet()) {
+                // The Old* implementations are matched by class name here just to avoid the Reflection hassle
+                // of retrieving their classes, since they're package-private
+                if ("org.hibernate.cache.internal.OldCacheKeyImplementation".equals(clazz.getName())) {
+                    cacheKeySerializerFound = true;
+                } else if ("org.hibernate.cache.internal.OldNaturalIdCacheKey".equals(clazz.getName())) {
+                    naturalIdKeySerializerFound = true;
+                } else if (StandardCacheEntryImpl.class.equals(clazz)) {
+                    cacheEntrySerializerFound = true;
+                }
+            }
+
+            assertFalse("CacheKey serializer found", cacheKeySerializerFound);
+            assertFalse("CacheEntry serializer found", cacheEntrySerializerFound);
+            assertFalse("NaturalIdCacheKey serializer found", naturalIdKeySerializerFound);
+        } finally {
+            thread.setContextClassLoader(tccl);
+        }
+    }
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
@@ -1,0 +1,80 @@
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.internal.util.compare.ComparableComparator;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ValueTest {
+
+    @Test
+    public void testGetValue() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertEquals(expectedValue, value.getValue());
+    }
+
+    @Test
+    public void testGetValueWithTimestampBefore() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertNull(value.getValue(99L));
+    }
+
+    @Test
+    public void testGetValueWithTimestampEqual() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertEquals(expectedValue, value.getValue(100L));
+    }
+
+    @Test
+    public void testGetValueWithTimestampAfter() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertEquals(expectedValue, value.getValue(101L));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampBefore() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertFalse(value.isReplaceableBy(99L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampEqual() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertTrue(value.isReplaceableBy(100L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampAfter() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertTrue(value.isReplaceableBy(101L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionBefore() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(10, 100L, expectedValue);
+        assertFalse(value.isReplaceableBy(99L, 9, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionEqual() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(10, 100L, expectedValue);
+        assertFalse(value.isReplaceableBy(101L, 10, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionAfter() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(10, 100L, expectedValue);
+        assertTrue(value.isReplaceableBy(99L, 11, ComparableComparator.INSTANCE));
+    }
+
+}

--- a/hazelcast-hibernate5/src/test/resources/hazelcast-client-custom.xml
+++ b/hazelcast-hibernate5/src/test/resources/hazelcast-client-custom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
+                  xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+</hazelcast-client>

--- a/hazelcast-hibernate5/src/test/resources/hazelcast-custom.xml
+++ b/hazelcast-hibernate5/src/test/resources/hazelcast-custom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.4.xsd">
+    <group>
+        <name>dev-custom</name>
+        <password>dev-pass</password>
+    </group>
+    <network>
+        <port auto-increment="true">5701</port>
+        <join>
+            <multicast enabled="false">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+        <interfaces enabled="false">
+            <interface>10.3.17.*</interface>
+        </interfaces>
+    </network>
+    <map name="default">
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. Valid numbers are 0 (no backup), 1, 2, 3.
+        -->
+        <backup-count>1</backup-count>
+        <!--
+            Valid values are:
+            NONE (no eviction),
+            LRU (Least Recently Used),
+            LFU (Least Frequiently Used).
+            NONE is the default.
+        -->
+        <eviction-policy>NONE</eviction-policy>
+        <!--
+            Maximum size of the map. When max size is reached,
+            map is evicted based on the policy defined.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size>0</max-size>
+        <!--
+            When max. size is reached, specified percentage of
+            the map will be evicted. Any integer between 0 and 100.
+            If 25 is set for example, 25% of the entries will
+            get evicted.
+        -->
+        <eviction-percentage>25</eviction-percentage>
+    </map>
+
+    <!-- Config for query cache -->
+    <map name="org.hibernate.cache.*">
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <max-size>50</max-size>
+    </map>
+</hazelcast>

--- a/hazelcast-hibernate5/src/test/resources/hbm/DummyEntity.xml
+++ b/hazelcast-hibernate5/src/test/resources/hbm/DummyEntity.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="com.hazelcast.hibernate.entity">
+    <class name="DummyEntity" table="dummy_entities">
+        <cache usage="%1$s"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="assigned"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="name" type="string" length="100"/>
+        <property name="date" column="dummy_date" type="date"/>
+        <property name="value" column="dummy_value" type="double"/>
+
+        <set name="properties" lazy="false" cascade="all" inverse="true">
+            <cache usage="%1$s"/>
+            <key column="parent_uid"/>
+            <one-to-many class="com.hazelcast.hibernate.entity.DummyProperty"/>
+        </set>
+    </class>
+</hibernate-mapping>

--- a/hazelcast-hibernate5/src/test/resources/hbm/DummyProperty.xml
+++ b/hazelcast-hibernate5/src/test/resources/hbm/DummyProperty.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="com.hazelcast.hibernate.entity">
+    <class name="DummyProperty" table="dummy_props">
+        <cache usage="%1$s"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="native"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="key" type="string" length="100"/>
+
+        <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntity"
+                     column="parent_uid"/>
+    </class>
+</hibernate-mapping>

--- a/hazelcast-hibernate5/src/test/resources/test-hibernate-client.cfg.xml
+++ b/hazelcast-hibernate5/src/test/resources/test-hibernate-client.cfg.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.dialect">org.hibernate.dialect.HSQLDialect</property>
+        <property name="hibernate.connection.driver_class">org.hsqldb.jdbcDriver</property>
+        <property name="hibernate.connection.url">jdbc:hsqldb:mem:testdb</property>
+        <property name="hibernate.connection.username">sa</property>
+        <property name="hibernate.connection.password"/>
+
+        <property name="hibernate.connection.pool_size">2</property>
+        <property name="hibernate.show_sql">false</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+
+        <property name="hibernate.cache.use_second_level_cache">true</property>
+        <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.cache.use_minimal_puts">true</property>
+
+        <property name="hibernate.cache.hazelcast.use_native_client">true</property>
+        <property name="hibernate.cache.hazelcast.native_client_address">localhost</property>
+        <property name="hibernate.cache.hazelcast.native_client_group">dev-custom</property>
+        <property name="hibernate.cache.hazelcast.native_client_password">dev-pass</property>
+        <property name="hibernate.cache.hazelcast.explicit_version_check">true</property>
+    </session-factory>
+</hibernate-configuration>

--- a/hazelcast-hibernate5/src/test/resources/test-hibernate.cfg.xml
+++ b/hazelcast-hibernate5/src/test/resources/test-hibernate.cfg.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.dialect">org.hibernate.dialect.HSQLDialect</property>
+        <property name="hibernate.connection.driver_class">org.hsqldb.jdbcDriver</property>
+        <property name="hibernate.connection.url">jdbc:hsqldb:mem:testdb</property>
+        <property name="hibernate.connection.username">sa</property>
+        <property name="hibernate.connection.password"/>
+
+        <property name="hibernate.connection.pool_size">2</property>
+        <property name="hibernate.show_sql">false</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+
+        <property name="hibernate.cache.use_second_level_cache">true</property>
+        <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.cache.use_minimal_puts">true</property>
+
+        <property name="hibernate.cache.hazelcast.configuration_file_path">hazelcast-custom.xml</property>
+    </session-factory>
+</hibernate-configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <modules>
         <module>hazelcast-hibernate3</module>
         <module>hazelcast-hibernate4</module>
+        <module>hazelcast-hibernate5</module>
     </modules>
 
     <properties>
@@ -83,11 +84,9 @@
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.language>java</sonar.language>
         <sonar.verbose>true</sonar.verbose>
-        <!-- needed for checkstyle/findbugs -->
 
         <hsqldb.version>2.2.9</hsqldb.version>
-        <javaassist.version>3.12.1.GA</javaassist.version>
-        <hazelcast.version>3.6</hazelcast.version>
+        <javassist.version>3.18.1-GA</javassist.version>
     </properties>
 
     <licenses>
@@ -320,9 +319,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javassist</groupId>
+            <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>${javaassist.version}</version>
+            <version>${javassist.version}</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
For simplicity in the code, the `hazelcast-hibernate5` module is compiled against Hibernate 5.0.7 instead of 5.1.0. The tests have been run against both 5.0.7 and 5.1.0 and pass, but it's simpler to compile against 5.0.7 because CacheEntry still has the areLazyPropertiesUnfetched() method. In order to compile against 5.1.0, the Hibernate5CacheEntrySerializer would need to be reimplemented serialize entirely via Reflection in order to capture the areLazyPropertiesUnfetched() value.
- Essentially duplicates hazelcast-hibernate4, with API/SPI updates for Hibernate 5
- Unlike Hibernate 4, on Hibernate 5 there are different cache key types for collection/entity and natural ID, so two serializers are required
  - The CacheKey class has been renamed to OldCacheKeyImplementation, and is now package-private, so serialization must be done entirely via Reflection
  - The StreamSerializer implementations for both of the key types are StreamSerializer<Object> because the types they're bound to are package-private

This pull request replaces [hazelcast/hazelcast#7021](https://github.com/hazelcast/hazelcast/pull/7021).
