### PR TITLE
Use LocalRegionCaches for natural IDs in HazelcastLocalCacheRegionFactory.

### DIFF
--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -20,13 +20,10 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.instance.HazelcastInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
 import com.hazelcast.hibernate.local.CleanupService;
-import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
 import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.spi.CacheDataDescription;
-import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.QueryResultsRegion;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.AccessType;
@@ -35,7 +32,7 @@ import org.hibernate.cfg.Settings;
 import java.util.Properties;
 
 /**
- * Abstract superclass of Hazelcast based {@link org.hibernate.cache.RegionFactory} implementations
+ * Abstract superclass of Hazelcast based {@link org.hibernate.cache.spi.RegionFactory} implementations
  */
 public abstract class AbstractHazelcastCacheRegionFactory implements RegionFactory {
 
@@ -62,12 +59,6 @@ public abstract class AbstractHazelcastCacheRegionFactory implements RegionFacto
         HazelcastQueryResultsRegion region = new HazelcastQueryResultsRegion(instance, regionName, properties);
         cleanupService.registerCache(region.getCache());
         return region;
-    }
-
-    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties
-            , final CacheDataDescription metadata)
-            throws CacheException {
-        return new HazelcastNaturalIdRegion(instance, regionName, properties, metadata);
     }
 
     /**

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
@@ -20,13 +20,10 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.distributed.IMapRegionCache;
 import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
 import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
 import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.spi.RegionFactory;
-import org.hibernate.cache.spi.CacheDataDescription;
-import org.hibernate.cache.spi.CollectionRegion;
-import org.hibernate.cache.spi.EntityRegion;
-import org.hibernate.cache.spi.TimestampsRegion;
+import org.hibernate.cache.spi.*;
 
 import java.util.Properties;
 
@@ -55,6 +52,12 @@ public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFac
     public EntityRegion buildEntityRegion(final String regionName, final Properties properties,
                                           final CacheDataDescription metadata) throws CacheException {
         return new HazelcastEntityRegion<IMapRegionCache>(instance, regionName, properties, metadata,
+                new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
+                                                final CacheDataDescription metadata) throws CacheException {
+        return new HazelcastNaturalIdRegion<IMapRegionCache>(instance, regionName, properties, metadata,
                 new IMapRegionCache(regionName, instance, properties, metadata));
     }
 

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -21,16 +21,12 @@ import com.hazelcast.hibernate.local.LocalRegionCache;
 import com.hazelcast.hibernate.local.TimestampsRegionCache;
 import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
 import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
 import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.spi.CacheDataDescription;
-import org.hibernate.cache.spi.CollectionRegion;
-import org.hibernate.cache.spi.EntityRegion;
-import org.hibernate.cache.spi.RegionFactory;
-import org.hibernate.cache.spi.TimestampsRegion;
+import org.hibernate.cache.spi.*;
 
 import java.util.Properties;
-
 
 /**
  * Simple RegionFactory implementation to return Hazelcast based local Region implementations
@@ -62,6 +58,14 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
                                           final CacheDataDescription metadata) throws CacheException {
         final HazelcastEntityRegion<LocalRegionCache> region = new HazelcastEntityRegion<LocalRegionCache>(instance,
                 regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
+                                                final CacheDataDescription metadata) throws CacheException {
+        final HazelcastNaturalIdRegion<LocalRegionCache> region = new HazelcastNaturalIdRegion<LocalRegionCache>(
+                instance, regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
         cleanupService.registerCache(region.getCache());
         return region;
     }

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
@@ -17,10 +17,10 @@
 package com.hazelcast.hibernate.region;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
 import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
 import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
 import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
-import com.hazelcast.hibernate.distributed.IMapRegionCache;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.NaturalIdRegion;
@@ -32,12 +32,14 @@ import java.util.Properties;
 /**
  * Hazelcast based implementation used to store NaturalIds
  */
-public class HazelcastNaturalIdRegion extends AbstractTransactionalDataRegion<IMapRegionCache>
+public class HazelcastNaturalIdRegion<Cache extends RegionCache>
+        extends AbstractTransactionalDataRegion<Cache>
         implements NaturalIdRegion {
 
     public HazelcastNaturalIdRegion(final HazelcastInstance instance, final String regionName,
-                                    final Properties props, final CacheDataDescription metadata) {
-        super(instance, regionName, props, metadata, new IMapRegionCache(regionName, instance, props, metadata));
+                                    final Properties props, final CacheDataDescription metadata,
+                                    final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
     }
 
     public NaturalIdRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {


### PR DESCRIPTION
- Made HazelcastNaturalIdRegion generic so it can be instantiated with a LocalRegionCache instead of an IMapRegionCache
- Removed the default implementation for buildNaturalIdRegion from AbstractHazelcastCacheRegionFactory
- Added an IMapRegionCache-based buildNaturalIdRegion implementation in HazelcastCacheRegionFactory, to match its other regions
- Added a LocalRegionCache-based buildNaturalIdRegion implementation in HazelcastLocalCacheRegionFactory, to match its other regions
