### PR TITLE
Fix a bug in collection eviction

### DIFF
--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
@@ -52,11 +52,11 @@ public final class CollectionRegionAccessStrategyAdapter implements CollectionRe
     }
 
     public SoftLock lockItem(final Object key, final Object version) throws CacheException {
-        return delegate.lockItem(key, version);
+        return null;
     }
 
     public SoftLock lockRegion() throws CacheException {
-        return delegate.lockRegion();
+        return null;
     }
 
     public boolean putFromLoad(final Object key, final Object value, final long txTimestamp, final Object version)
@@ -78,10 +78,8 @@ public final class CollectionRegionAccessStrategyAdapter implements CollectionRe
     }
 
     public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
-        delegate.unlockItem(key, lock);
     }
 
     public void unlockRegion(final SoftLock lock) throws CacheException {
-        delegate.unlockRegion(lock);
     }
 }


### PR DESCRIPTION
Before, the collection  (many to many relation) was locked, which resulted in inserting ExpiryMarker into Hazelcast, which prevented the eviction. In result, the collection was never evicted.