### PR TITLE
Fix bug collection eviction

### DIFF
--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -138,6 +138,10 @@ public final class CacheEnvironment {
         return timeout;
     }
 
+    public static int getMaximumLockTimeoutInMillis() {
+        return MAXIMUM_LOCK_TIMEOUT;
+    }
+
     public static boolean shutdownOnStop(Properties props, boolean defaultValue) {
         return ConfigurationHelper.getBoolean(CacheEnvironment.SHUTDOWN_ON_STOP, props, defaultValue);
     }

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -219,7 +219,7 @@ public class LocalRegionCache implements RegionCache {
         String markerId = nextMarkerId();
         while (true) {
             final Expirable original = cache.get(key);
-            long timeout = nextTimestamp() + CacheEnvironment.getDefaultCacheTimeoutInMillis();
+            long timeout = nextTimestamp() + CacheEnvironment.getMaximumLockTimeoutInMillis();
             if (original == null) {
                 marker = new ExpiryMarker(version, timeout, markerId);
                 if (cache.putIfAbsent(key, marker) == null) {
@@ -356,6 +356,9 @@ public class LocalRegionCache implements RegionCache {
             final Object k = e.getKey();
             final Expirable expirable = e.getValue();
             if (expirable instanceof ExpiryMarker) {
+                if (((ExpiryMarker) expirable).getTimeout() < now) {
+                    iter.remove();
+                }
                 continue;
             }
             final Value v = (Value) expirable;

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
@@ -52,11 +52,11 @@ public final class CollectionRegionAccessStrategyAdapter implements CollectionRe
     }
 
     public SoftLock lockItem(final Object key, final Object version) throws CacheException {
-        return null;
+        return delegate.lockItem(key, version);
     }
 
     public SoftLock lockRegion() throws CacheException {
-        return null;
+        return delegate.lockRegion();
     }
 
     public boolean putFromLoad(final Object key, final Object value, final long txTimestamp, final Object version)
@@ -78,8 +78,10 @@ public final class CollectionRegionAccessStrategyAdapter implements CollectionRe
     }
 
     public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        delegate.unlockItem(key, lock);
     }
 
     public void unlockRegion(final SoftLock lock) throws CacheException {
+        delegate.unlockRegion(lock);
     }
 }

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
@@ -155,4 +155,7 @@ public class ExpiryMarker extends Expirable implements Serializable {
         return HibernateDataSerializerHook.EXPIRY_MARKER;
     }
 
+    public long getTimeout() {
+        return timeout;
+    }
 }


### PR DESCRIPTION
Provides a fix for the bug reported in the Zendesk tickets:
- https://hazelcast.zendesk.com/agent/tickets/4795
- https://hazelcast.zendesk.com/agent/tickets/4645

Changes:
- Revert #43 (it was too naive solution, which removed locking for the collections at all; the locking is however needed for some cases)
- Decrease `timeout` of ExpiryMarker from DEFAULT_CACHE_TIMEOUT (1h) to MAXIMUM_LOCK_TIMEOUT (10s) - 1h without cleanup of ExpiryMarker is too long
- Add cleanup of ExpiryMarkers (before ExpiryMarkers were never cleaned up)

The most questionable change is decreasing the timeout for ExpiryMarker, however 10s is the value already used in the IMapRegionCache implementation, plus I believe ExpiryMarkers are actually just an optimization (if we cleaned up the cache entries instead of marking them with ExpiryMarker, it should work correctly).