### PR TITLE
add guava and reflections deps to fix jenkins failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,6 +551,24 @@
             <properties>
                 <hazelcast.version>3.12-SNAPSHOT</hazelcast.version>
             </properties>
+            <!-- These dependencies are just workaround to prevent master build failures at jenkins:
+                    CustomPropertiesTest.testNamedInstance_noInstance()
+                    CustomPropertiesTest.testNamedClient_noInstance()
+            -->
+            <dependencies>
+                <dependency>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                    <version>15.0</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.reflections</groupId>
+                    <artifactId>reflections</artifactId>
+                    <version>0.9.10</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
I can not find the main cause of these failures at [Hibernate-master](http://jenkins.hazelcast.com/view/Plugins/job/Hibernate-master/) and [Hibernate-5-master](http://jenkins.hazelcast.com/view/Plugins/job/Hibernate-5-master/):
```
Expected: (an instance of org.hibernate.cache.CacheException and exception with message a string containing "No client with name [dev-custom] could be found.")
     but: an instance of org.hibernate.cache.CacheException <java.lang.NoClassDefFoundError: com/google/common/base/Predicate> is a java.lang.NoClassDefFoundError
Stacktrace was: java.lang.NoClassDefFoundError: com/google/common/base/Predicate
```
Until we find the main cause, this workaround prevents to fail master builds.