### PR TITLE
Apply group config and UUID changes

### DIFF
--- a/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -59,7 +59,7 @@ public final class CacheEnvironment {
     /**
      * Property to configure Hazelcast client group name
      */
-    public static final String NATIVE_CLIENT_GROUP = "hibernate.cache.hazelcast.native_client_group";
+    public static final String NATIVE_CLIENT_CLUSTER = "hibernate.cache.hazelcast.native_client_group";
 
     /**
      * Property to configure Hazelcast client group password

--- a/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -174,6 +174,6 @@ public class IMapRegionCache implements RegionCache {
     }
 
     private String nextMarkerId() {
-        return hazelcastInstance.getLocalEndpoint().getUuid() + markerIdCounter.getAndIncrement();
+        return hazelcastInstance.getLocalEndpoint().getUuid().toString() + markerIdCounter.getAndIncrement();
     }
 }

--- a/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -48,7 +48,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         }
 
         String address = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
-        String group = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+        String group = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER, props, null);
         String pass = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
         String configResourcePath = CacheEnvironment.getConfigFilePath(props);
 
@@ -63,10 +63,10 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         }
 
         if (group != null) {
-            clientConfig.getGroupConfig().setName(group);
+            clientConfig.setClusterName(group);
         }
         if (pass != null) {
-            clientConfig.getGroupConfig().setPassword(pass);
+            clientConfig.setClusterPassword(pass);
         }
         if (address != null) {
             clientConfig.getNetworkConfig().addAddress(address);

--- a/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
+++ b/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
@@ -62,7 +62,7 @@ public class CustomPropertiesTest extends HibernateTestSupport {
         props.remove(CacheEnvironment.CONFIG_FILE_PATH_LEGACY);
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
-        props.setProperty(CacheEnvironment.NATIVE_CLIENT_GROUP, "dev-custom");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_CLUSTER, "dev-custom");
         props.setProperty(CacheEnvironment.NATIVE_CLIENT_PASSWORD, "dev-pass");
         props.setProperty(CacheEnvironment.NATIVE_CLIENT_ADDRESS, "localhost");
         props.setProperty(CacheEnvironment.CONFIG_FILE_PATH,"hazelcast-client-custom.xml");
@@ -75,8 +75,8 @@ public class CustomPropertiesTest extends HibernateTestSupport {
         assertEquals(1, main.getCluster().getMembers().size());
         HazelcastClientProxy client = (HazelcastClientProxy) hz;
         ClientConfig clientConfig = client.getClientConfig();
-        assertEquals("dev-custom", clientConfig.getGroupConfig().getName());
-        assertEquals("dev-pass", clientConfig.getGroupConfig().getPassword());
+        assertEquals("dev-custom", clientConfig.getClusterName());
+        assertEquals("dev-pass", clientConfig.getClusterPassword());
         assertTrue(clientConfig.getNetworkConfig().isSmartRouting());
         assertTrue(clientConfig.getNetworkConfig().isRedoOperation());
         factory.newHazelcastInstance(config);

--- a/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -40,16 +40,16 @@ public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
                 unloadInstance();
             }
             String address = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
-            String group = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+            String cluster = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER, props, null);
             String pass = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
             String configResourcePath = CacheEnvironment.getConfigFilePath(props);
 
             ClientConfig clientConfig = buildClientConfig(configResourcePath);
-            if (group != null) {
-                clientConfig.getGroupConfig().setName(group);
+            if (cluster != null) {
+                clientConfig.setClusterName(cluster);
             }
             if (pass != null) {
-                clientConfig.getGroupConfig().setPassword(pass);
+                clientConfig.setClusterPassword(pass);
             }
             if (address != null) {
                 clientConfig.getNetworkConfig().addAddress(address);

--- a/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -14,6 +14,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Comparator;
+import java.util.UUID;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -89,7 +90,7 @@ public class LocalRegionCacheTest {
         when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
 
         ITopic<Object> topic = mock(ITopic.class);
-        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn("ignored");
+        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn(UUID.randomUUID());
 
         HazelcastInstance instance = mock(HazelcastInstance.class);
         when(instance.getConfig()).thenReturn(config);

--- a/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
+++ b/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
@@ -22,6 +22,8 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
 
+import java.util.UUID;
+
 @RunWith(MockitoJUnitRunner.class)
 public class TimestampsRegionCacheTest {
 
@@ -49,7 +51,7 @@ public class TimestampsRegionCacheTest {
         when(member.localMember()).thenReturn(false);
 
         ArgumentCaptor<MessageListener> listener = ArgumentCaptor.forClass(MessageListener.class);
-        when(topic.addMessageListener(listener.capture())).thenReturn("ignored");
+        when(topic.addMessageListener(listener.capture())).thenReturn(UUID.randomUUID());
         target = new TimestampsRegionCache(CACHE_NAME, instance);
         this.listener = listener.getValue();
     }

--- a/hazelcast-hibernate3/src/test/resources/hazelcast-custom.xml
+++ b/hazelcast-hibernate3/src/test/resources/hazelcast-custom.xml
@@ -19,10 +19,10 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
-    <group>
+    <cluster>
         <name>dev-custom</name>
         <password>dev-pass</password>
-    </group>
+    </cluster>
     <network>
         <port auto-increment="true">5701</port>
         <join>

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -53,7 +53,7 @@ public final class CacheEnvironment {
     /**
      * Property to configure Hazelcast client group name
      */
-    public static final String NATIVE_CLIENT_GROUP = "hibernate.cache.hazelcast.native_client_group";
+    public static final String NATIVE_CLIENT_CLUSTER = "hibernate.cache.hazelcast.native_client_group";
 
     /**
      * Property to configure Hazelcast client group password

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -169,7 +169,7 @@ public class IMapRegionCache implements RegionCache {
     }
 
     private String nextMarkerId() {
-        return hazelcastInstance.getLocalEndpoint().getUuid() + markerIdCounter.getAndIncrement();
+        return hazelcastInstance.getLocalEndpoint().getUuid().toString() + markerIdCounter.getAndIncrement();
     }
 
 }

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -48,7 +48,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         }
 
         String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
-        String group = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+        String cluster = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER, props, null);
         String pass = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
         String configResourcePath = CacheEnvironment.getConfigFilePath(props);
 
@@ -62,11 +62,11 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
             clientConfig = new ClientConfig();
         }
 
-        if (group != null) {
-            clientConfig.getGroupConfig().setName(group);
+        if (cluster != null) {
+            clientConfig.setClusterName(cluster);
         }
         if (pass != null) {
-            clientConfig.getGroupConfig().setPassword(pass);
+            clientConfig.setClusterPassword(pass);
         }
         if (address != null) {
             clientConfig.getNetworkConfig().addAddress(address);

--- a/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
+++ b/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
@@ -67,7 +67,7 @@ public class CustomPropertiesTest extends HibernateTestSupport {
         props.remove(CacheEnvironment.CONFIG_FILE_PATH_LEGACY);
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
-        props.setProperty(CacheEnvironment.NATIVE_CLIENT_GROUP, "dev-custom");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_CLUSTER, "dev-custom");
         props.setProperty(CacheEnvironment.NATIVE_CLIENT_PASSWORD, "dev-pass");
         props.setProperty(CacheEnvironment.NATIVE_CLIENT_ADDRESS, "localhost");
         props.setProperty(CacheEnvironment.CONFIG_FILE_PATH,"hazelcast-client-custom.xml");
@@ -80,8 +80,8 @@ public class CustomPropertiesTest extends HibernateTestSupport {
         assertEquals(1, main.getCluster().getMembers().size());
         HazelcastClientProxy client = (HazelcastClientProxy) hz;
         ClientConfig clientConfig = client.getClientConfig();
-        assertEquals("dev-custom", clientConfig.getGroupConfig().getName());
-        assertEquals("dev-pass", clientConfig.getGroupConfig().getPassword());
+        assertEquals("dev-custom", clientConfig.getClusterName());
+        assertEquals("dev-pass", clientConfig.getClusterPassword());
         assertTrue(clientConfig.getNetworkConfig().isSmartRouting());
         assertTrue(clientConfig.getNetworkConfig().isRedoOperation());
         factory.newHazelcastInstance(config);

--- a/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -40,16 +40,16 @@ public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
                 unloadInstance();
             }
             String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
-            String group = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+            String cluster = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER, props, null);
             String pass = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
             String configResourcePath = CacheEnvironment.getConfigFilePath(props);
 
             ClientConfig clientConfig = buildClientConfig(configResourcePath);
-            if (group != null) {
-                clientConfig.getGroupConfig().setName(group);
+            if (cluster != null) {
+                clientConfig.setClusterName(cluster);
             }
             if (pass != null) {
-                clientConfig.getGroupConfig().setPassword(pass);
+                clientConfig.setClusterPassword(pass);
             }
             if (address != null) {
                 clientConfig.getNetworkConfig().addAddress(address);

--- a/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -17,6 +17,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Comparator;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
@@ -93,7 +94,7 @@ public class LocalRegionCacheTest {
         when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
 
         ITopic<Object> topic = mock(ITopic.class);
-        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn("ignored");
+        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn(UUID.randomUUID());
 
         HazelcastInstance instance = mock(HazelcastInstance.class);
         when(instance.getConfig()).thenReturn(config);

--- a/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
+++ b/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
@@ -22,6 +22,8 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
 
+import java.util.UUID;
+
 @RunWith(MockitoJUnitRunner.class)
 public class TimestampsRegionCacheTest {
 
@@ -49,7 +51,7 @@ public class TimestampsRegionCacheTest {
         when(member.localMember()).thenReturn(false);
 
         ArgumentCaptor<MessageListener> listener = ArgumentCaptor.forClass(MessageListener.class);
-        when(topic.addMessageListener(listener.capture())).thenReturn("ignored");
+        when(topic.addMessageListener(listener.capture())).thenReturn(UUID.randomUUID());
         target = new TimestampsRegionCache(CACHE_NAME, instance);
         this.listener = listener.getValue();
     }

--- a/hazelcast-hibernate4/src/test/resources/hazelcast-custom.xml
+++ b/hazelcast-hibernate4/src/test/resources/hazelcast-custom.xml
@@ -19,10 +19,10 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
-    <group>
+    <cluster>
         <name>dev-custom</name>
         <password>dev-pass</password>
-    </group>
+    </cluster>
     <network>
         <port auto-increment="true">5701</port>
         <join>


### PR DESCRIPTION
- String types of UUIDs are converted to java.util.UUID.

- GroupConfig property is removed. instance.getCluster[name|password] is used instead.

- NATIVE_CLIENT_GROUP property is renamed as NATIVE_CLIENT_CLUSTER

- Util package is moved to internal.

hibernate.cache.hazelcast.native_client_group property name is not changed for now. If it would be the documentation (README.md) has to be modified for Hazelcast4.x versions accordingly.