### PR TITLE
Remove max attempt property from client config

### DIFF
--- a/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -34,7 +34,9 @@ import java.util.Properties;
  */
 class HazelcastClientLoader implements IHazelcastInstanceLoader {
 
-    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+    private static final int INITIAL_BACKOFF_MS = 2000;
+    private static final int MAX_BACKOFF_MS = 35000;
+    private static final double BACKOFF_MULTIPLIER = 1.5D;
 
     private HazelcastInstance client;
     private ClientConfig clientConfig;
@@ -74,7 +76,13 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
 
         clientConfig.getNetworkConfig().setSmartRouting(true);
         clientConfig.getNetworkConfig().setRedoOperation(true);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+
+        // Try to connect a cluster with intervals starting with 2 sec and multiplied by 1.5
+        // at each step. When the last waiting interval time exceeds 35 seconds, it fails.
+        // This corresponds to 8 trials in total.
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setInitialBackoffMillis(INITIAL_BACKOFF_MS);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(MAX_BACKOFF_MS);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMultiplier(BACKOFF_MULTIPLIER);
     }
 
     @Override

--- a/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -2,6 +2,7 @@ package com.hazelcast.hibernate.instance;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.ConnectionRetryConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
@@ -21,7 +22,9 @@ import java.util.Properties;
 public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
 
     private static final ILogger LOGGER = Logger.getLogger(HazelcastMockInstanceLoader.class);
-    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+    private static final int INITIAL_BACKOFF_MS = 2000;
+    private static final int MAX_BACKOFF_MS = 35000;
+    private static final double BACKOFF_MULTIPLIER = 1.5D;
 
     private final Properties props = new Properties();
     private String instanceName;
@@ -168,9 +171,12 @@ public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
         if (clientConfig == null) {
             clientConfig = new ClientConfig();
             final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+            final ConnectionRetryConfig connectionRetryConfig = clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig();
             networkConfig.setSmartRouting(true);
             networkConfig.setRedoOperation(true);
-            networkConfig.setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+            connectionRetryConfig.setInitialBackoffMillis(INITIAL_BACKOFF_MS);
+            connectionRetryConfig.setMaxBackoffMillis(MAX_BACKOFF_MS);
+            connectionRetryConfig.setMultiplier(BACKOFF_MULTIPLIER);
         }
         return clientConfig;
     }

--- a/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -34,7 +34,9 @@ import java.util.Properties;
  */
 class HazelcastClientLoader implements IHazelcastInstanceLoader {
 
-    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+    private static final int INITIAL_BACKOFF_MS = 2000;
+    private static final int MAX_BACKOFF_MS = 35000;
+    private static final double BACKOFF_MULTIPLIER = 1.5D;
 
     private HazelcastInstance client;
     private ClientConfig clientConfig;
@@ -74,7 +76,13 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
 
         clientConfig.getNetworkConfig().setSmartRouting(true);
         clientConfig.getNetworkConfig().setRedoOperation(true);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+
+        // Try to connect a cluster with intervals starting with 2 sec and multiplied by 1.5
+        // at each step. When the last waiting interval time exceeds 35 seconds, it fails.
+        // This corresponds to 8 trials in total.
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setInitialBackoffMillis(INITIAL_BACKOFF_MS);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(MAX_BACKOFF_MS);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMultiplier(BACKOFF_MULTIPLIER);
     }
 
     @Override

--- a/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -2,6 +2,7 @@ package com.hazelcast.hibernate.instance;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.ConnectionRetryConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
@@ -21,7 +22,9 @@ import java.util.Properties;
 public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
 
     private static final ILogger LOGGER = Logger.getLogger(HazelcastMockInstanceLoader.class);
-    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+    private static final int INITIAL_BACKOFF_MS = 2000;
+    private static final int MAX_BACKOFF_MS = 35000;
+    private static final double BACKOFF_MULTIPLIER = 1.5D;
 
     private final Properties props = new Properties();
     private String instanceName;
@@ -168,9 +171,12 @@ public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
         if (clientConfig == null) {
             clientConfig = new ClientConfig();
             final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+            final ConnectionRetryConfig connectionRetryConfig = clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig();
             networkConfig.setSmartRouting(true);
             networkConfig.setRedoOperation(true);
-            networkConfig.setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+            connectionRetryConfig.setInitialBackoffMillis(INITIAL_BACKOFF_MS);
+            connectionRetryConfig.setMaxBackoffMillis(MAX_BACKOFF_MS);
+            connectionRetryConfig.setMultiplier(BACKOFF_MULTIPLIER);
         }
         return clientConfig;
     }


### PR DESCRIPTION
The changes on client protocol concerning connection interval and limit are applied.
See the related PR [here](https://github.com/hazelcast/hazelcast/pull/15675).